### PR TITLE
Update includes to support BuildSettingsVersion.V2

### DIFF
--- a/Plugins/InternalComponentVisualizer/Source/InternalComponentVisualizer/Private/InternalComponentVisualizer.cpp
+++ b/Plugins/InternalComponentVisualizer/Source/InternalComponentVisualizer/Private/InternalComponentVisualizer.cpp
@@ -1,8 +1,8 @@
 #include "InternalComponentVisualizer.h"
 #include "InternalComponentVisualizerPCH.h"
 #include "HeliumRain/Spacecrafts/FlareInternalComponent.h"
-#include "UnrealEd.h"
-#include "ComponentVisualizer.h"
+#include <UnrealEd.h>
+#include <ComponentVisualizer.h>
 
 /*----------------------------------------------------
 	Visualizer

--- a/Plugins/InternalComponentVisualizer/Source/InternalComponentVisualizer/Private/InternalComponentVisualizer.h
+++ b/Plugins/InternalComponentVisualizer/Source/InternalComponentVisualizer/Private/InternalComponentVisualizer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ModuleManager.h"
+#include <Modules/ModuleManager.h>
 
 class InternalComponentVisualizerImpl : public IModuleInterface
 {

--- a/Plugins/JoystickPlugin/Source/JoystickPlugin/Private/JoystickDevice.cpp
+++ b/Plugins/JoystickPlugin/Source/JoystickPlugin/Private/JoystickDevice.cpp
@@ -6,7 +6,7 @@
 #include "DeviceSDL.h"
 
 #include <SlateBasics.h>
-#include <Text.h>
+#include <Internationalization/Text.h>
 
 #define LOCTEXT_NAMESPACE "JoystickPlugin"
 

--- a/Plugins/JoystickPlugin/Source/JoystickPlugin/Private/JoystickPlugin.cpp
+++ b/Plugins/JoystickPlugin/Source/JoystickPlugin/Private/JoystickPlugin.cpp
@@ -3,7 +3,7 @@
 #include <Engine.h>
 
 #if WITH_EDITOR
-	#include "InputSettingsCustomization.h"
+#include "InputSettingsCustomization.h"
 #endif
 
 IMPLEMENT_MODULE(FJoystickPlugin, JoystickPlugin)

--- a/Plugins/JoystickPlugin/Source/JoystickPlugin/Private/JoystickPluginPrivatePCH.h
+++ b/Plugins/JoystickPlugin/Source/JoystickPlugin/Private/JoystickPluginPrivatePCH.h
@@ -3,5 +3,5 @@
 // add includes for headers that are used in most of your module's source files though.
 
 
-#include "Engine.h"
-#include "CoreUObject.h"
+#include <Engine.h>
+#include <CoreUObject.h>

--- a/Plugins/JoystickPlugin/Source/JoystickPlugin/Public/IJoystickPlugin.h
+++ b/Plugins/JoystickPlugin/Source/JoystickPlugin/Public/IJoystickPlugin.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <ModuleManager.h>
+#include <Modules/ModuleManager.h>
 #include <IInputDeviceModule.h>
 
 /**

--- a/Plugins/JoystickPlugin/Source/JoystickPlugin/Public/JoystickInterface.h
+++ b/Plugins/JoystickPlugin/Source/JoystickPlugin/Public/JoystickInterface.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Engine.h"
+#include <Engine.h>
 #include "JoystickInterface.generated.h"
 
 struct FDeviceIndex

--- a/Source/HeliumRain/Data/FlareAsteroidCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareAsteroidCatalog.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareAsteroidCatalog.h"
+#include "HeliumRain/Data/FlareAsteroidCatalog.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareAsteroidCatalog.h
+++ b/Source/HeliumRain/Data/FlareAsteroidCatalog.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Flare.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareAsteroidCatalog.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareCameraShakeCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareCameraShakeCatalog.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareCameraShakeCatalog.h"
+#include "HeliumRain/Data/FlareCameraShakeCatalog.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareCameraShakeCatalog.h
+++ b/Source/HeliumRain/Data/FlareCameraShakeCatalog.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Flare.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareCameraShakeCatalog.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareCompanyCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareCompanyCatalog.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareCompanyCatalog.h"
+#include "HeliumRain/Data/FlareCompanyCatalog.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareCompanyCatalog.h
+++ b/Source/HeliumRain/Data/FlareCompanyCatalog.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Game/FlareCompany.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareCompanyCatalog.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareCustomizationCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareCustomizationCatalog.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareCustomizationCatalog.h"
+#include "HeliumRain/Data/FlareCustomizationCatalog.h"
 #include "../Flare.h"
 #include "../Game/FlareGameTools.h"
 

--- a/Source/HeliumRain/Data/FlareCustomizationCatalog.h
+++ b/Source/HeliumRain/Data/FlareCustomizationCatalog.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Flare.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareCustomizationCatalog.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareFactoryCatalogEntry.cpp
+++ b/Source/HeliumRain/Data/FlareFactoryCatalogEntry.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareFactoryCatalogEntry.h"
+#include "HeliumRain/Data/FlareFactoryCatalogEntry.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareFactoryCatalogEntry.h
+++ b/Source/HeliumRain/Data/FlareFactoryCatalogEntry.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Economy/FlareFactory.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareFactoryCatalogEntry.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareMeteoriteCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareMeteoriteCatalog.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareMeteoriteCatalog.h"
+#include "HeliumRain/Data/FlareMeteoriteCatalog.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareMeteoriteCatalog.h
+++ b/Source/HeliumRain/Data/FlareMeteoriteCatalog.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Flare.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareMeteoriteCatalog.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareOrbitalMap.cpp
+++ b/Source/HeliumRain/Data/FlareOrbitalMap.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareOrbitalMap.h"
+#include "HeliumRain/Data/FlareOrbitalMap.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareOrbitalMap.h
+++ b/Source/HeliumRain/Data/FlareOrbitalMap.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Game/FlareSimulatedSector.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareOrbitalMap.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareQuestCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareQuestCatalog.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareQuestCatalog.h"
+#include "HeliumRain/Data/FlareQuestCatalog.h"
 #include "../Flare.h"
-#include "AssetRegistryModule.h"
+#include <AssetRegistryModule.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Data/FlareQuestCatalog.h
+++ b/Source/HeliumRain/Data/FlareQuestCatalog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareQuestCatalogEntry.h"
+#include "HeliumRain/Data/FlareQuestCatalogEntry.h"
 #include "FlareQuestCatalog.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareQuestCatalogEntry.cpp
+++ b/Source/HeliumRain/Data/FlareQuestCatalogEntry.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareQuestCatalogEntry.h"
+#include "HeliumRain/Data/FlareQuestCatalogEntry.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareQuestCatalogEntry.h
+++ b/Source/HeliumRain/Data/FlareQuestCatalogEntry.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Quests/FlareQuest.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareQuestCatalogEntry.generated.h"
 
 /** Quest action type */

--- a/Source/HeliumRain/Data/FlareResourceCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareResourceCatalog.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareResourceCatalog.h"
+#include "HeliumRain/Data/FlareResourceCatalog.h"
 #include "../Flare.h"
-#include "AssetRegistryModule.h"
+#include <AssetRegistryModule.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Data/FlareResourceCatalogEntry.cpp
+++ b/Source/HeliumRain/Data/FlareResourceCatalogEntry.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareResourceCatalogEntry.h"
+#include "HeliumRain/Data/FlareResourceCatalogEntry.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareResourceCatalogEntry.h
+++ b/Source/HeliumRain/Data/FlareResourceCatalogEntry.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Economy/FlareResource.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareResourceCatalogEntry.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareScannableCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareScannableCatalog.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareScannableCatalog.h"
+#include "HeliumRain/Data/FlareScannableCatalog.h"
 #include "../Flare.h"
-#include "AssetRegistryModule.h"
+#include <AssetRegistryModule.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Data/FlareScannableCatalog.h
+++ b/Source/HeliumRain/Data/FlareScannableCatalog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareScannableCatalogEntry.h"
+#include "HeliumRain/Data/FlareScannableCatalogEntry.h"
 #include "FlareScannableCatalog.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareScannableCatalogEntry.cpp
+++ b/Source/HeliumRain/Data/FlareScannableCatalogEntry.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareScannableCatalogEntry.h"
+#include "HeliumRain/Data/FlareScannableCatalogEntry.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareScannableCatalogEntry.h
+++ b/Source/HeliumRain/Data/FlareScannableCatalogEntry.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Game/FlareGameTypes.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareScannableCatalogEntry.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareSectorCatalogEntry.cpp
+++ b/Source/HeliumRain/Data/FlareSectorCatalogEntry.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSectorCatalogEntry.h"
+#include "HeliumRain/Data/FlareSectorCatalogEntry.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareSectorCatalogEntry.h
+++ b/Source/HeliumRain/Data/FlareSectorCatalogEntry.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Game/FlareSector.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareSectorCatalogEntry.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareSpacecraftCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareSpacecraftCatalog.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareSpacecraftCatalog.h"
+#include "HeliumRain/Data/FlareSpacecraftCatalog.h"
 #include "../Flare.h"
-#include "AssetRegistryModule.h"
+#include <AssetRegistryModule.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Data/FlareSpacecraftCatalog.h
+++ b/Source/HeliumRain/Data/FlareSpacecraftCatalog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSpacecraftCatalogEntry.h"
+#include "HeliumRain/Data/FlareSpacecraftCatalogEntry.h"
 #include "../Spacecrafts/FlareSpacecraft.h"
 #include "FlareSpacecraftCatalog.generated.h"
 

--- a/Source/HeliumRain/Data/FlareSpacecraftCatalogEntry.cpp
+++ b/Source/HeliumRain/Data/FlareSpacecraftCatalogEntry.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftCatalogEntry.h"
+#include "HeliumRain/Data/FlareSpacecraftCatalogEntry.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareSpacecraftCatalogEntry.h
+++ b/Source/HeliumRain/Data/FlareSpacecraftCatalogEntry.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Spacecrafts/FlareSpacecraftTypes.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareSpacecraftCatalogEntry.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareSpacecraftComponentsCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareSpacecraftComponentsCatalog.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareSpacecraftComponentsCatalog.h"
+#include "HeliumRain/Data/FlareSpacecraftComponentsCatalog.h"
 #include "../Flare.h"
 #include "../Player/FlarePlayerController.h"
-#include "AssetRegistryModule.h"
+#include <AssetRegistryModule.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Data/FlareSpacecraftComponentsCatalog.h
+++ b/Source/HeliumRain/Data/FlareSpacecraftComponentsCatalog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSpacecraftComponentsCatalogEntry.h"
+#include "HeliumRain/Data/FlareSpacecraftComponentsCatalogEntry.h"
 #include "FlareSpacecraftComponentsCatalog.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareSpacecraftComponentsCatalogEntry.cpp
+++ b/Source/HeliumRain/Data/FlareSpacecraftComponentsCatalogEntry.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftComponentsCatalogEntry.h"
+#include "HeliumRain/Data/FlareSpacecraftComponentsCatalogEntry.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareSpacecraftComponentsCatalogEntry.h
+++ b/Source/HeliumRain/Data/FlareSpacecraftComponentsCatalogEntry.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Spacecrafts/FlareSpacecraftComponent.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareSpacecraftComponentsCatalogEntry.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareTechnologyCatalog.cpp
+++ b/Source/HeliumRain/Data/FlareTechnologyCatalog.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareTechnologyCatalog.h"
+#include "HeliumRain/Data/FlareTechnologyCatalog.h"
 #include "../Flare.h"
-#include "AssetRegistryModule.h"
+#include <AssetRegistryModule.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Data/FlareTechnologyCatalog.h
+++ b/Source/HeliumRain/Data/FlareTechnologyCatalog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareTechnologyCatalogEntry.h"
+#include "HeliumRain/Data/FlareTechnologyCatalogEntry.h"
 #include "FlareTechnologyCatalog.generated.h"
 
 

--- a/Source/HeliumRain/Data/FlareTechnologyCatalogEntry.cpp
+++ b/Source/HeliumRain/Data/FlareTechnologyCatalogEntry.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareTechnologyCatalogEntry.h"
+#include "HeliumRain/Data/FlareTechnologyCatalogEntry.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Data/FlareTechnologyCatalogEntry.h
+++ b/Source/HeliumRain/Data/FlareTechnologyCatalogEntry.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../Game/FlareGameTypes.h"
-#include "Engine/DataAsset.h"
+#include <Engine/DataAsset.h>
 #include "FlareTechnologyCatalogEntry.generated.h"
 
 

--- a/Source/HeliumRain/Economy/FlareCargoBay.cpp
+++ b/Source/HeliumRain/Economy/FlareCargoBay.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareCargoBay.h"
+#include "HeliumRain/Economy/FlareCargoBay.h"
 #include "../Flare.h"
 
-#include "FlareFactory.h"
+#include "HeliumRain/Economy/FlareFactory.h"
 
 #include "../Data/FlareResourceCatalog.h"
 

--- a/Source/HeliumRain/Economy/FlareCargoBay.h
+++ b/Source/HeliumRain/Economy/FlareCargoBay.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Spacecrafts/FlareSpacecraftTypes.h"
-#include "FlareResource.h"
+#include "HeliumRain/Economy/FlareResource.h"
 #include "FlareCargoBay.generated.h"
 
 

--- a/Source/HeliumRain/Economy/FlareFactory.cpp
+++ b/Source/HeliumRain/Economy/FlareFactory.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareFactory.h"
+#include "HeliumRain/Economy/FlareFactory.h"
 #include "../Flare.h"
 
 #include "../Data/FlareResourceCatalog.h"

--- a/Source/HeliumRain/Economy/FlareFactory.h
+++ b/Source/HeliumRain/Economy/FlareFactory.h
@@ -1,6 +1,6 @@
 
 #pragma once
-#include "FlareResource.h"
+#include "HeliumRain/Economy/FlareResource.h"
 #include "../Data/FlareResourceCatalogEntry.h"
 #include "../Game/FlareWorld.h"
 #include "FlareFactory.generated.h"

--- a/Source/HeliumRain/Economy/FlarePeople.cpp
+++ b/Source/HeliumRain/Economy/FlarePeople.cpp
@@ -1,5 +1,5 @@
 
-#include "FlarePeople.h"
+#include "HeliumRain/Economy/FlarePeople.h"
 #include "../Flare.h"
 
 #include "../Data/FlareResourceCatalog.h"
@@ -10,7 +10,7 @@
 
 #include "../Spacecrafts/FlareSimulatedSpacecraft.h"
 
-#include "FlareCargoBay.h"
+#include "HeliumRain/Economy/FlareCargoBay.h"
 
 
 #define LOCTEXT_NAMESPACE "FlarePeopleInfo"

--- a/Source/HeliumRain/Economy/FlareResource.cpp
+++ b/Source/HeliumRain/Economy/FlareResource.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareResource.h"
+#include "HeliumRain/Economy/FlareResource.h"
 #include "../Flare.h"
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Flare.cpp
+++ b/Source/HeliumRain/Flare.cpp
@@ -1,15 +1,15 @@
 
-#include "Flare.h"
-#include "UI/Style/FlareStyleSet.h"
-#include "Game/FlareGame.h"
-#include "Game/Save/FlareSaveGameSystem.h"
+#include "HeliumRain/Flare.h"
+#include "HeliumRain/UI/Style/FlareStyleSet.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/Save/FlareSaveGameSystem.h"
 
-#include "Runtime/Online/HTTP/Public/Http.h"
-#include "Runtime/Online/HTTP/Public/HttpManager.h"
-#include "HAL/PlatformStackWalk.h"
-#include "HAL/PlatformProcess.h"
-#include "HAL/PlatformTime.h"
-#include "Engine.h"
+#include <Http.h>
+#include <HttpManager.h>
+#include <HAL/PlatformStackWalk.h>
+#include <HAL/PlatformProcess.h>
+#include <HAL/PlatformTime.h>
+#include <Engine.h>
 
 
 IMPLEMENT_PRIMARY_GAME_MODULE(FFlareModule, HeliumRain, "HeliumRain");

--- a/Source/HeliumRain/Flare.h
+++ b/Source/HeliumRain/Flare.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "EngineMinimal.h"
+#include <EngineMinimal.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Game/AI/FlareAIBehavior.cpp
+++ b/Source/HeliumRain/Game/AI/FlareAIBehavior.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareAIBehavior.h"
+#include "HeliumRain/Game/AI/FlareAIBehavior.h"
 #include "../../Flare.h"
 
 #include "../../Data/FlareResourceCatalog.h"

--- a/Source/HeliumRain/Game/AI/FlareAIBehavior.h
+++ b/Source/HeliumRain/Game/AI/FlareAIBehavior.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../FlareGameTypes.h"
 #include "FlareAIBehavior.generated.h"
 

--- a/Source/HeliumRain/Game/AI/FlareAITradeHelper.cpp
+++ b/Source/HeliumRain/Game/AI/FlareAITradeHelper.cpp
@@ -1,4 +1,4 @@
-#include "FlareAITradeHelper.h"
+#include "HeliumRain/Game/AI/FlareAITradeHelper.h"
 
 #include "../FlareGame.h"
 #include "../FlareCompany.h"
@@ -16,7 +16,7 @@
 #include "../../Spacecrafts/FlareSimulatedSpacecraft.h"
 #include "../../Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
 
-#include "FlareAIBehavior.h"
+#include "HeliumRain/Game/AI/FlareAIBehavior.h"
 #include <functional>
 
 

--- a/Source/HeliumRain/Game/AI/FlareAITradeHelper.h
+++ b/Source/HeliumRain/Game/AI/FlareAITradeHelper.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../FlareGameTypes.h"
 
 #define DEBUG_NEW_AI_TRADING 0

--- a/Source/HeliumRain/Game/AI/FlareCompanyAI.cpp
+++ b/Source/HeliumRain/Game/AI/FlareCompanyAI.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareCompanyAI.h"
+#include "HeliumRain/Game/AI/FlareCompanyAI.h"
 #include "../../Flare.h"
-#include "FlareAIBehavior.h"
-#include "FlareAITradeHelper.h"
+#include "HeliumRain/Game/AI/FlareAIBehavior.h"
+#include "HeliumRain/Game/AI/FlareAITradeHelper.h"
 
 #include "../FlareGame.h"
 #include "../FlareGameTools.h"

--- a/Source/HeliumRain/Game/AI/FlareCompanyAI.h
+++ b/Source/HeliumRain/Game/AI/FlareCompanyAI.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../FlareGameTypes.h"
 #include "../FlareWorldHelper.h"
-#include "FlareAITradeHelper.h"
+#include "HeliumRain/Game/AI/FlareAITradeHelper.h"
 #include "FlareCompanyAI.generated.h"
 
 

--- a/Source/HeliumRain/Game/AI/FlareTacticManager.cpp
+++ b/Source/HeliumRain/Game/AI/FlareTacticManager.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareTacticManager.h"
+#include "HeliumRain/Game/AI/FlareTacticManager.h"
 #include "../../Flare.h"
 #include "../FlareCompany.h"
 #include "../FlareGame.h"

--- a/Source/HeliumRain/Game/AI/FlareTacticManager.h
+++ b/Source/HeliumRain/Game/AI/FlareTacticManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../FlareGameTypes.h"
 #include "FlareTacticManager.generated.h"
 

--- a/Source/HeliumRain/Game/FlareAsteroid.cpp
+++ b/Source/HeliumRain/Game/FlareAsteroid.cpp
@@ -1,11 +1,11 @@
 
-#include "FlareAsteroid.h"
+#include "HeliumRain/Game/FlareAsteroid.h"
 #include "../Flare.h"
-#include "FlareGame.h"
-#include "FlarePlanetarium.h"
-#include "FlareSimulatedSector.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlarePlanetarium.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
 
-#include "StaticMeshResources.h"
+#include <StaticMeshResources.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Game/FlareAsteroid.h
+++ b/Source/HeliumRain/Game/FlareAsteroid.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Spacecrafts/FlareSpacecraftTypes.h"
-#include "FlareAsteroidComponent.h"
+#include "HeliumRain/Game/FlareAsteroidComponent.h"
 #include "FlareAsteroid.generated.h"
 
 

--- a/Source/HeliumRain/Game/FlareAsteroidComponent.cpp
+++ b/Source/HeliumRain/Game/FlareAsteroidComponent.cpp
@@ -1,12 +1,12 @@
 
-#include "FlareAsteroidComponent.h"
+#include "HeliumRain/Game/FlareAsteroidComponent.h"
 #include "../Flare.h"
 
-#include "FlareGame.h"
-#include "FlarePlanetarium.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlarePlanetarium.h"
 #include "../Player/FlarePlayerController.h"
 
-#include "StaticMeshResources.h"
+#include <StaticMeshResources.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Game/FlareBattle.cpp
+++ b/Source/HeliumRain/Game/FlareBattle.cpp
@@ -1,10 +1,10 @@
 
 
-#include "FlareBattle.h"
+#include "HeliumRain/Game/FlareBattle.h"
 #include "../Flare.h"
-#include "FlareWorld.h"
-#include "FlareGame.h"
-#include "FlareGameTools.h"
+#include "HeliumRain/Game/FlareWorld.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareGameTools.h"
 
 #include "../Data/FlareSpacecraftComponentsCatalog.h"
 

--- a/Source/HeliumRain/Game/FlareBattle.h
+++ b/Source/HeliumRain/Game/FlareBattle.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Object.h"
-#include "FlareSimulatedSector.h"
+#include <UObject/Object.h>
+#include "HeliumRain/Game/FlareSimulatedSector.h"
 #include "FlareBattle.generated.h"
 
 class UFlareSpacecraftComponentsCatalog;

--- a/Source/HeliumRain/Game/FlareCollider.cpp
+++ b/Source/HeliumRain/Game/FlareCollider.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareCollider.h"
+#include "HeliumRain/Game/FlareCollider.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Game/FlareCompany.cpp
+++ b/Source/HeliumRain/Game/FlareCompany.cpp
@@ -1,11 +1,11 @@
 
-#include "FlareCompany.h"
-#include "Flare.h"
-#include "FlareGame.h"
-#include "FlareGameTools.h"
-#include "FlareSector.h"
-#include "FlareGameUserSettings.h"
-#include "FlareScenarioTools.h"
+#include "HeliumRain/Game/FlareCompany.h"
+#include "HeliumRain/Flare.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareGameTools.h"
+#include "HeliumRain/Game/FlareSector.h"
+#include "HeliumRain/Game/FlareGameUserSettings.h"
+#include "HeliumRain/Game/FlareScenarioTools.h"
 
 #include "../Economy/FlareCargoBay.h"
 #include "../Economy/FlareFactory.h"
@@ -18,8 +18,8 @@
 #include "../Spacecrafts/FlareSpacecraft.h"
 #include "../Spacecrafts/FlareSimulatedSpacecraft.h"
 
-#include "AI/FlareCompanyAI.h"
-#include "AI/FlareAIBehavior.h"
+#include "HeliumRain/Game/AI/FlareCompanyAI.h"
+#include "HeliumRain/Game/AI/FlareAIBehavior.h"
 
 
 #define LOCTEXT_NAMESPACE "FlareCompany"

--- a/Source/HeliumRain/Game/FlareCompany.h
+++ b/Source/HeliumRain/Game/FlareCompany.h
@@ -1,12 +1,12 @@
 
 #pragma once
 
-#include "Object.h"
-#include "FlareFleet.h"
-#include "FlareGameTypes.h"
-#include "FlareSimulatedSector.h"
-#include "AI/FlareCompanyAI.h"
-#include "AI/FlareTacticManager.h"
+#include <UObject/Object.h>
+#include "HeliumRain/Game/FlareFleet.h"
+#include "HeliumRain/Game/FlareGameTypes.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
+#include "HeliumRain/Game/AI/FlareCompanyAI.h"
+#include "HeliumRain/Game/AI/FlareTacticManager.h"
 #include "../Spacecrafts/FlareSimulatedSpacecraft.h"
 #include "FlareCompany.generated.h"
 

--- a/Source/HeliumRain/Game/FlareDebrisField.cpp
+++ b/Source/HeliumRain/Game/FlareDebrisField.cpp
@@ -1,11 +1,11 @@
 
-#include "FlareDebrisField.h"
+#include "HeliumRain/Game/FlareDebrisField.h"
 #include "../Flare.h"
-#include "FlareGame.h"
-#include "FlareSimulatedSector.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
 
-#include "Engine/StaticMeshActor.h"
-#include "StaticMeshResources.h"
+#include <Engine/StaticMeshActor.h>
+#include <StaticMeshResources.h>
 
 #define LOCTEXT_NAMESPACE "FlareDebrisField"
 

--- a/Source/HeliumRain/Game/FlareDebrisField.h
+++ b/Source/HeliumRain/Game/FlareDebrisField.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "FlareDebrisField.generated.h"
 
 

--- a/Source/HeliumRain/Game/FlareFleet.cpp
+++ b/Source/HeliumRain/Game/FlareFleet.cpp
@@ -1,11 +1,11 @@
 
-#include "FlareFleet.h"
+#include "HeliumRain/Game/FlareFleet.h"
 #include "../Flare.h"
 
-#include "FlareCompany.h"
-#include "FlareGame.h"
-#include "FlareGameTools.h"
-#include "FlareSimulatedSector.h"
+#include "HeliumRain/Game/FlareCompany.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareGameTools.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
 
 #include "../Economy/FlareCargoBay.h"
 

--- a/Source/HeliumRain/Game/FlareFleet.h
+++ b/Source/HeliumRain/Game/FlareFleet.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../Data/FlareResourceCatalogEntry.h"
 #include "../Spacecrafts/FlareSpacecraftTypes.h"
 #include "FlareFleet.generated.h"

--- a/Source/HeliumRain/Game/FlareGame.cpp
+++ b/Source/HeliumRain/Game/FlareGame.cpp
@@ -1,17 +1,17 @@
 
-#include "FlareGame.h"
+#include "HeliumRain/Game/FlareGame.h"
 #include "../Flare.h"
 
-#include "FlareSaveGame.h"
-#include "FlareWorld.h"
-#include "FlareAsteroid.h"
-#include "FlareDebrisField.h"
-#include "FlarePlanetarium.h"
-#include "FlareGameTools.h"
-#include "FlareScenarioTools.h"
-#include "FlareSkirmishManager.h"
+#include "HeliumRain/Game/FlareSaveGame.h"
+#include "HeliumRain/Game/FlareWorld.h"
+#include "HeliumRain/Game/FlareAsteroid.h"
+#include "HeliumRain/Game/FlareDebrisField.h"
+#include "HeliumRain/Game/FlarePlanetarium.h"
+#include "HeliumRain/Game/FlareGameTools.h"
+#include "HeliumRain/Game/FlareScenarioTools.h"
+#include "HeliumRain/Game/FlareSkirmishManager.h"
 
-#include "Save/FlareSaveGameSystem.h"
+#include "HeliumRain/Game/Save/FlareSaveGameSystem.h"
 
 #include "../Data/FlareSpacecraftCatalog.h"
 #include "../Data/FlareSpacecraftComponentsCatalog.h"
@@ -39,11 +39,11 @@
 
 #include "../Quests/FlareQuestManager.h"
 
-#include "AssetRegistryModule.h"
-#include "Log/FlareLogWriter.h"
+#include <AssetRegistryModule.h>
+#include "HeliumRain/Game/Log/FlareLogWriter.h"
 
-#include "Engine/PostProcessVolume.h"
-#include "Engine.h"
+#include <Engine/PostProcessVolume.h>
+#include <Engine.h>
 
 #define LOCTEXT_NAMESPACE "FlareGame"
 

--- a/Source/HeliumRain/Game/FlareGame.h
+++ b/Source/HeliumRain/Game/FlareGame.h
@@ -2,12 +2,12 @@
 
 
 #include "../Spacecrafts/FlareSpacecraft.h"
-#include "FlareGameTypes.h"
-#include "FlareCompany.h"
-#include "FlareSector.h"
-#include "Log/FlareLogApi.h"
+#include "HeliumRain/Game/FlareGameTypes.h"
+#include "HeliumRain/Game/FlareCompany.h"
+#include "HeliumRain/Game/FlareSector.h"
+#include "HeliumRain/Game/Log/FlareLogApi.h"
 
-#include "GameFramework/GameMode.h"
+#include <GameFramework/GameMode.h>
 #include "FlareGame.generated.h"
 
 #define DEBUG_AI_TRADING_STATS 0

--- a/Source/HeliumRain/Game/FlareGameTools.cpp
+++ b/Source/HeliumRain/Game/FlareGameTools.cpp
@@ -1,11 +1,11 @@
 
-#include "FlareGameTools.h"
+#include "HeliumRain/Game/FlareGameTools.h"
 #include "../Flare.h"
 
-#include "FlareGame.h"
-#include "FlareCompany.h"
-#include "FlarePlanetarium.h"
-#include "FlareSectorHelper.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareCompany.h"
+#include "HeliumRain/Game/FlarePlanetarium.h"
+#include "HeliumRain/Game/FlareSectorHelper.h"
 
 #include "../Data/FlareFactoryCatalogEntry.h"
 #include "../Data/FlareResourceCatalog.h"
@@ -17,9 +17,9 @@
 #include "../Player/FlareMenuManager.h"
 #include "../Player/FlarePlayerController.h"
 
-#include "Quests/FlareQuest.h"
-#include "Quests/FlareQuestStep.h"
-#include "Quests/FlareQuestManager.h"
+#include "HeliumRain/Quests/FlareQuest.h"
+#include "HeliumRain/Quests/FlareQuestStep.h"
+#include "HeliumRain/Quests/FlareQuestManager.h"
 
 #define LOCTEXT_NAMESPACE "FlareGameTools"
 

--- a/Source/HeliumRain/Game/FlareGameTools.h
+++ b/Source/HeliumRain/Game/FlareGameTools.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Flare.h"
-#include "GameFramework/CheatManager.h"
+#include <GameFramework/CheatManager.h>
 #include "FlareGameTools.generated.h"
 
 class UFlareWorld;

--- a/Source/HeliumRain/Game/FlareGameTypes.cpp
+++ b/Source/HeliumRain/Game/FlareGameTypes.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareGameTypes.h"
+#include "HeliumRain/Game/FlareGameTypes.h"
 #include "../UI/FlareUITypes.h"
 #include "../Flare.h"
 #include "../Spacecrafts/FlareSpacecraft.h"

--- a/Source/HeliumRain/Game/FlareGameTypes.h
+++ b/Source/HeliumRain/Game/FlareGameTypes.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "../Flare.h"
-#include "FlareFleet.h"
-#include "FlareTradeRoute.h"
+#include "HeliumRain/Game/FlareFleet.h"
+#include "HeliumRain/Game/FlareTradeRoute.h"
 #include "../Spacecrafts/FlareSpacecraftTypes.h"
 #include "FlareGameTypes.generated.h"
 

--- a/Source/HeliumRain/Game/FlareGameUserSettings.cpp
+++ b/Source/HeliumRain/Game/FlareGameUserSettings.cpp
@@ -1,11 +1,11 @@
 
-#include "FlareGameUserSettings.h"
+#include "HeliumRain/Game/FlareGameUserSettings.h"
 #include "../Flare.h"
-#include "FlareGame.h"
+#include "HeliumRain/Game/FlareGame.h"
 #include "../Player/FlarePlayerController.h"
 
-#include "EngineUtils.h"
-#include "Engine.h"
+#include <EngineUtils.h>
+#include <Engine.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Game/FlareGameUserSettings.h
+++ b/Source/HeliumRain/Game/FlareGameUserSettings.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Flare.h"
-#include "GameFramework/GameUserSettings.h"
+#include <GameFramework/GameUserSettings.h>
 #include "FlareGameUserSettings.generated.h"
 
 

--- a/Source/HeliumRain/Game/FlarePlanetarium.cpp
+++ b/Source/HeliumRain/Game/FlarePlanetarium.cpp
@@ -1,12 +1,12 @@
 
-#include "FlarePlanetarium.h"
+#include "HeliumRain/Game/FlarePlanetarium.h"
 #include "../Flare.h"
-#include "FlareGame.h"
+#include "HeliumRain/Game/FlareGame.h"
 #include "../Player/FlarePlayerController.h"
 
-#include "EngineUtils.h"
-#include "Engine.h"
-#include "Materials/MaterialInstanceConstant.h"
+#include <EngineUtils.h>
+#include <Engine.h>
+#include <Materials/MaterialInstanceConstant.h>
 
 
 //#define PLANETARIUM_DEBUG

--- a/Source/HeliumRain/Game/FlarePlanetarium.h
+++ b/Source/HeliumRain/Game/FlarePlanetarium.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "../Game/Planetarium/FlareSimulatedPlanetarium.h"
-#include "Components/DirectionalLightComponent.h"
-#include "GameFramework/Actor.h"
+#include <Components/DirectionalLightComponent.h>
+#include <GameFramework/Actor.h>
 
 #include "FlarePlanetarium.generated.h"
 

--- a/Source/HeliumRain/Game/FlareSaveGame.cpp
+++ b/Source/HeliumRain/Game/FlareSaveGame.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSaveGame.h"
+#include "HeliumRain/Game/FlareSaveGame.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Game/FlareSaveGame.h
+++ b/Source/HeliumRain/Game/FlareSaveGame.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "FlareCompany.h"
-#include "FlareWorld.h"
+#include "HeliumRain/Game/FlareCompany.h"
+#include "HeliumRain/Game/FlareWorld.h"
 #include "../Quests/FlareQuestManager.h"
-#include "GameFramework/SaveGame.h"
+#include <GameFramework/SaveGame.h>
 #include "FlareSaveGame.generated.h"
 
 

--- a/Source/HeliumRain/Game/FlareScannable.cpp
+++ b/Source/HeliumRain/Game/FlareScannable.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareScannable.h"
+#include "HeliumRain/Game/FlareScannable.h"
 #include "../Flare.h"
 
 #include "../Player/FlarePlayerController.h"

--- a/Source/HeliumRain/Game/FlareScenarioTools.cpp
+++ b/Source/HeliumRain/Game/FlareScenarioTools.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareScenarioTools.h"
+#include "HeliumRain/Game/FlareScenarioTools.h"
 #include "../Flare.h"
 
 #include "../Data/FlareResourceCatalog.h"

--- a/Source/HeliumRain/Game/FlareScenarioTools.h
+++ b/Source/HeliumRain/Game/FlareScenarioTools.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSimulatedSector.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
 #include "FlareScenarioTools.generated.h"
 
 class UFlareWorld;

--- a/Source/HeliumRain/Game/FlareSector.cpp
+++ b/Source/HeliumRain/Game/FlareSector.cpp
@@ -1,11 +1,11 @@
 
-#include "FlareSector.h"
+#include "HeliumRain/Game/FlareSector.h"
 #include "../Flare.h"
 
-#include "FlareGame.h"
-#include "FlarePlanetarium.h"
-#include "FlareSimulatedSector.h"
-#include "FlareCollider.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlarePlanetarium.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
+#include "HeliumRain/Game/FlareCollider.h"
 
 #include "../Player/FlarePlayerController.h"
 

--- a/Source/HeliumRain/Game/FlareSector.h
+++ b/Source/HeliumRain/Game/FlareSector.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../Spacecrafts/FlareSpacecraft.h"
 #include "../Spacecrafts/FlareBomb.h"
-#include "FlareAsteroid.h"
+#include "HeliumRain/Game/FlareAsteroid.h"
 #include "../Quests/FlareMeteorite.h"
-#include "FlareSimulatedSector.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
 #include "FlareSector.generated.h"
 
 class UFlareSimulatedSector;

--- a/Source/HeliumRain/Game/FlareSectorHelper.cpp
+++ b/Source/HeliumRain/Game/FlareSectorHelper.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSectorHelper.h"
+#include "HeliumRain/Game/FlareSectorHelper.h"
 #include "../Flare.h"
 
 #include "../Data/FlareResourceCatalog.h"
@@ -8,10 +8,10 @@
 #include "../Economy/FlareFactory.h"
 #include "../Economy/FlareCargoBay.h"
 
-#include "FlareCompany.h"
-#include "FlareGame.h"
-#include "FlareWorld.h"
-#include "FlareScenarioTools.h"
+#include "HeliumRain/Game/FlareCompany.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareWorld.h"
+#include "HeliumRain/Game/FlareScenarioTools.h"
 
 #include "../Player/FlarePlayerController.h"
 

--- a/Source/HeliumRain/Game/FlareSectorHelper.h
+++ b/Source/HeliumRain/Game/FlareSectorHelper.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareWorldHelper.h"
+#include "HeliumRain/Game/FlareWorldHelper.h"
 #include "../Economy/FlareResource.h"
 #include "../Game/FlareTradeRoute.h"
 #include "../Spacecrafts/FlareSimulatedSpacecraft.h"

--- a/Source/HeliumRain/Game/FlareSimulatedSector.cpp
+++ b/Source/HeliumRain/Game/FlareSimulatedSector.cpp
@@ -1,11 +1,11 @@
 
-#include "FlareSimulatedSector.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
 #include "../Flare.h"
-#include "FlareWorld.h"
-#include "FlareFleet.h"
-#include "FlareGame.h"
-#include "FlareGameTools.h"
-#include "FlareGameUserSettings.h"
+#include "HeliumRain/Game/FlareWorld.h"
+#include "HeliumRain/Game/FlareFleet.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareGameTools.h"
+#include "HeliumRain/Game/FlareGameUserSettings.h"
 #include <random>
 
 #include "../Data/FlareResourceCatalog.h"
@@ -19,9 +19,9 @@
 
 #include "../Spacecrafts/FlareSimulatedSpacecraft.h"
 #include "../Quests/FlareQuestGenerator.h"
-#include "FlareSectorHelper.h"
+#include "HeliumRain/Game/FlareSectorHelper.h"
 
-#include "Engine.h"
+#include <Engine.h>
 #include <ctime>
 
 

--- a/Source/HeliumRain/Game/FlareSimulatedSector.h
+++ b/Source/HeliumRain/Game/FlareSimulatedSector.h
@@ -1,8 +1,8 @@
 
 #pragma once
 
-#include "Object.h"
-#include "FlareAsteroid.h"
+#include <UObject/Object.h>
+#include "HeliumRain/Game/FlareAsteroid.h"
 #include "../Data/FlareAsteroidCatalog.h"
 #include "../Spacecrafts/FlareBomb.h"
 #include "../Economy/FlarePeople.h"

--- a/Source/HeliumRain/Game/FlareSkirmishManager.cpp
+++ b/Source/HeliumRain/Game/FlareSkirmishManager.cpp
@@ -1,11 +1,11 @@
 
 
-#include "FlareSkirmishManager.h"
+#include "HeliumRain/Game/FlareSkirmishManager.h"
 #include "../Flare.h"
 
-#include "FlareWorld.h"
-#include "FlareGame.h"
-#include "FlareGameTools.h"
+#include "HeliumRain/Game/FlareWorld.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareGameTools.h"
 
 #include "../Data/FlareCustomizationCatalog.h"
 

--- a/Source/HeliumRain/Game/FlareSkirmishManager.h
+++ b/Source/HeliumRain/Game/FlareSkirmishManager.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Object.h"
-#include "FlareSimulatedSector.h"
+#include <UObject/Object.h>
+#include "HeliumRain/Game/FlareSimulatedSector.h"
 #include "../Spacecrafts/FlareSpacecraftTypes.h"
 #include "FlareSkirmishManager.generated.h"
 

--- a/Source/HeliumRain/Game/FlareTradeRoute.cpp
+++ b/Source/HeliumRain/Game/FlareTradeRoute.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareTradeRoute.h"
+#include "HeliumRain/Game/FlareTradeRoute.h"
 #include "../Flare.h"
 
 #include "../Data/FlareResourceCatalog.h"
@@ -10,11 +10,11 @@
 
 #include "../Quests/FlareQuestManager.h"
 
-#include "FlareCompany.h"
-#include "FlareSimulatedSector.h"
-#include "FlareFleet.h"
-#include "FlareGame.h"
-#include "FlareSectorHelper.h"
+#include "HeliumRain/Game/FlareCompany.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
+#include "HeliumRain/Game/FlareFleet.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareSectorHelper.h"
 
 #define LOCTEXT_NAMESPACE "FlareTradeRouteInfos"
 

--- a/Source/HeliumRain/Game/FlareTradeRoute.h
+++ b/Source/HeliumRain/Game/FlareTradeRoute.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../Spacecrafts/FlareSpacecraftTypes.h"
 #include "FlareTradeRoute.generated.h"
 

--- a/Source/HeliumRain/Game/FlareTravel.cpp
+++ b/Source/HeliumRain/Game/FlareTravel.cpp
@@ -1,16 +1,16 @@
 
 
-#include "FlareTravel.h"
+#include "HeliumRain/Game/FlareTravel.h"
 #include "../Flare.h"
 
 #include "../Data/FlareResourceCatalog.h"
 
 #include "../Economy/FlareCargoBay.h"
 
-#include "FlareWorld.h"
-#include "FlareGame.h"
-#include "FlareGameTools.h"
-#include "FlareSectorHelper.h"
+#include "HeliumRain/Game/FlareWorld.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareGameTools.h"
+#include "HeliumRain/Game/FlareSectorHelper.h"
 
 #include "../Player/FlarePlayerController.h"
 

--- a/Source/HeliumRain/Game/FlareTravel.h
+++ b/Source/HeliumRain/Game/FlareTravel.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Object.h"
-#include "FlareSimulatedSector.h"
+#include <UObject/Object.h>
+#include "HeliumRain/Game/FlareSimulatedSector.h"
 #include "FlareTravel.generated.h"
 
 

--- a/Source/HeliumRain/Game/FlareWorld.cpp
+++ b/Source/HeliumRain/Game/FlareWorld.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareWorld.h"
+#include "HeliumRain/Game/FlareWorld.h"
 #include "../Flare.h"
 
 #include "../Data/FlareSpacecraftCatalog.h"
@@ -7,14 +7,14 @@
 
 #include "../Economy/FlareFactory.h"
 
-#include "FlareGame.h"
-#include "FlareGameTools.h"
-#include "FlareScenarioTools.h"
-#include "FlareSector.h"
-#include "FlareTravel.h"
-#include "FlareFleet.h"
-#include "FlareBattle.h"
-#include "AI/FlareAITradeHelper.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareGameTools.h"
+#include "HeliumRain/Game/FlareScenarioTools.h"
+#include "HeliumRain/Game/FlareSector.h"
+#include "HeliumRain/Game/FlareTravel.h"
+#include "HeliumRain/Game/FlareFleet.h"
+#include "HeliumRain/Game/FlareBattle.h"
+#include "HeliumRain/Game/AI/FlareAITradeHelper.h"
 
 #include "../Quests/FlareQuest.h"
 #include "../Quests/FlareQuestCondition.h"

--- a/Source/HeliumRain/Game/FlareWorld.h
+++ b/Source/HeliumRain/Game/FlareWorld.h
@@ -1,10 +1,10 @@
 
 #pragma once
 
-#include "Object.h"
-#include "FlareGameTypes.h"
-#include "FlareTravel.h"
-#include "Planetarium/FlareSimulatedPlanetarium.h"
+#include <UObject/Object.h>
+#include "HeliumRain/Game/FlareGameTypes.h"
+#include "HeliumRain/Game/FlareTravel.h"
+#include "HeliumRain/Game/Planetarium/FlareSimulatedPlanetarium.h"
 #include "FlareWorld.generated.h"
 
 

--- a/Source/HeliumRain/Game/FlareWorldHelper.cpp
+++ b/Source/HeliumRain/Game/FlareWorldHelper.cpp
@@ -1,14 +1,14 @@
 
-#include "FlareWorldHelper.h"
+#include "HeliumRain/Game/FlareWorldHelper.h"
 #include "../Flare.h"
 
 #include "../Data/FlareResourceCatalog.h"
 
-#include "FlareGame.h"
-#include "FlareWorld.h"
-#include "FlareSectorHelper.h"
-#include "FlareSimulatedSector.h"
-#include "FlareScenarioTools.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareWorld.h"
+#include "HeliumRain/Game/FlareSectorHelper.h"
+#include "HeliumRain/Game/FlareSimulatedSector.h"
+#include "HeliumRain/Game/FlareScenarioTools.h"
 
 #include "../Spacecrafts/FlareSimulatedSpacecraft.h"
 

--- a/Source/HeliumRain/Game/FlareWorldHelper.h
+++ b/Source/HeliumRain/Game/FlareWorldHelper.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "../Economy/FlareResource.h"
-#include "FlareWorld.h"
+#include "HeliumRain/Game/FlareWorld.h"
 
 struct WorldHelper
 {

--- a/Source/HeliumRain/Game/Log/FlareLogApi.cpp
+++ b/Source/HeliumRain/Game/Log/FlareLogApi.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareLogApi.h"
+#include "HeliumRain/Game/Log/FlareLogApi.h"
 #include "../../Flare.h"
-#include "FlareLogWriter.h"
+#include "HeliumRain/Game/Log/FlareLogWriter.h"
 
 #include "../FlareCompany.h"
 #include "../../Spacecrafts/FlareBomb.h"

--- a/Source/HeliumRain/Game/Log/FlareLogWriter.cpp
+++ b/Source/HeliumRain/Game/Log/FlareLogWriter.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareLogWriter.h"
+#include "HeliumRain/Game/Log/FlareLogWriter.h"
 #include "../../Flare.h"
-#include "FlareLogApi.h"
+#include "HeliumRain/Game/Log/FlareLogApi.h"
 #include "../Save/FlareSaveWriter.h"
 
 //***********************************************************

--- a/Source/HeliumRain/Game/Planetarium/FlareSimulatedPlanetarium.cpp
+++ b/Source/HeliumRain/Game/Planetarium/FlareSimulatedPlanetarium.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSimulatedPlanetarium.h"
+#include "HeliumRain/Game/Planetarium/FlareSimulatedPlanetarium.h"
 #include "../../Flare.h"
 #include "../FlareGame.h"
 

--- a/Source/HeliumRain/Game/Planetarium/FlareSimulatedPlanetarium.h
+++ b/Source/HeliumRain/Game/Planetarium/FlareSimulatedPlanetarium.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "FlareSimulatedPlanetarium.generated.h"
 
 class AFlareGame;

--- a/Source/HeliumRain/Game/Save/FlareSaveGameSystem.cpp
+++ b/Source/HeliumRain/Game/Save/FlareSaveGameSystem.cpp
@@ -1,9 +1,9 @@
 
-#include "FlareSaveGameSystem.h"
+#include "HeliumRain/Game/Save/FlareSaveGameSystem.h"
 #include "../../Flare.h"
 
-#include "FlareSaveWriter.h"
-#include "FlareSaveReaderV1.h"
+#include "HeliumRain/Game/Save/FlareSaveWriter.h"
+#include "HeliumRain/Game/Save/FlareSaveReaderV1.h"
 #include "../FlareGame.h"
 
 

--- a/Source/HeliumRain/Game/Save/FlareSaveGameSystem.h
+++ b/Source/HeliumRain/Game/Save/FlareSaveGameSystem.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "FlareSaveGameSystem.generated.h"
 
 class UFlareSaveGame;

--- a/Source/HeliumRain/Game/Save/FlareSaveReaderV1.cpp
+++ b/Source/HeliumRain/Game/Save/FlareSaveReaderV1.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareSaveReaderV1.h"
+#include "HeliumRain/Game/Save/FlareSaveReaderV1.h"
 #include "../../Flare.h"
 
-#include "FlareSaveWriter.h"
+#include "HeliumRain/Game/Save/FlareSaveWriter.h"
 
 #include "../FlareSaveGame.h"
 #include "../FlareGameTools.h"

--- a/Source/HeliumRain/Game/Save/FlareSaveReaderV1.h
+++ b/Source/HeliumRain/Game/Save/FlareSaveReaderV1.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../FlareSaveGame.h"
 #include "FlareSaveReaderV1.generated.h"
 

--- a/Source/HeliumRain/Game/Save/FlareSaveWriter.cpp
+++ b/Source/HeliumRain/Game/Save/FlareSaveWriter.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareSaveWriter.h"
+#include "HeliumRain/Game/Save/FlareSaveWriter.h"
 #include "../../Flare.h"
 #include "../FlareSaveGame.h"
-#include "Game/FlareGameTools.h"
+#include "HeliumRain/Game/FlareGameTools.h"
 
 /*----------------------------------------------------
 	Constructor

--- a/Source/HeliumRain/Game/Save/FlareSaveWriter.h
+++ b/Source/HeliumRain/Game/Save/FlareSaveWriter.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../FlareSaveGame.h"
 #include "FlareSaveWriter.generated.h"
 

--- a/Source/HeliumRain/Player/FlareCockpitManager.cpp
+++ b/Source/HeliumRain/Player/FlareCockpitManager.cpp
@@ -1,9 +1,9 @@
 
-#include "FlareCockpitManager.h"
+#include "HeliumRain/Player/FlareCockpitManager.h"
 #include "../Flare.h"
 
-#include "FlareHUD.h"
-#include "FlarePlayerController.h"
+#include "HeliumRain/Player/FlareHUD.h"
+#include "HeliumRain/Player/FlarePlayerController.h"
 
 #include "../Game/FlareGame.h"
 #include "../Quests/FlareQuestManager.h"
@@ -12,7 +12,7 @@
 #include "../Spacecrafts/FlareSpacecraftComponent.h"
 #include "../Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
 
-#include "Engine/CanvasRenderTarget2D.h"
+#include <Engine/CanvasRenderTarget2D.h>
 
 #define LOCTEXT_NAMESPACE "FlareCockpitManager"
 

--- a/Source/HeliumRain/Player/FlareCockpitManager.h
+++ b/Source/HeliumRain/Player/FlareCockpitManager.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "GameFramework/Actor.h"
-#include "Components/PointLightComponent.h"
+#include <GameFramework/Actor.h>
+#include <Components/PointLightComponent.h>
 #include "FlareCockpitManager.generated.h"
 
 class AFlareSpacecraft;

--- a/Source/HeliumRain/Player/FlareHUD.cpp
+++ b/Source/HeliumRain/Player/FlareHUD.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareHUD.h"
+#include "HeliumRain/Player/FlareHUD.h"
 #include "../Flare.h"
 
 #include "../Economy/FlareCargoBay.h"
@@ -22,9 +22,9 @@
 #include "../UI/HUD/FlareHUDMenu.h"
 #include "../UI/HUD/FlareContextMenu.h"
 
-#include "Engine/PostProcessVolume.h"
-#include "Engine/CanvasRenderTarget2D.h"
-#include "Engine/Canvas.h"
+#include <Engine/PostProcessVolume.h>
+#include <Engine/CanvasRenderTarget2D.h>
+#include <Engine/Canvas.h>
 #include "Engine/Engine.h"
 
 

--- a/Source/HeliumRain/Player/FlareHUD.h
+++ b/Source/HeliumRain/Player/FlareHUD.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "GameFramework/HUD.h"
-#include "FlareMenuManager.h"
+#include <GameFramework/HUD.h>
+#include "HeliumRain/Player/FlareMenuManager.h"
 #include "../Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
 #include "FlareHUD.generated.h"
 

--- a/Source/HeliumRain/Player/FlareMenuManager.cpp
+++ b/Source/HeliumRain/Player/FlareMenuManager.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareMenuManager.h"
+#include "HeliumRain/Player/FlareMenuManager.h"
 #include "../Flare.h"
 
 #include "../UI/Components/FlareTooltip.h"
@@ -34,14 +34,14 @@
 #include "../Game/FlareGameTools.h"
 #include "../Game/FlareSkirmishManager.h"
 
-#include "FlareHUD.h"
-#include "FlareMenuPawn.h"
-#include "FlarePlayerController.h"
+#include "HeliumRain/Player/FlareHUD.h"
+#include "HeliumRain/Player/FlareMenuPawn.h"
+#include "HeliumRain/Player/FlarePlayerController.h"
 
 #include "../HeliumRainLoadingScreen/FlareLoadingScreen.h"
 
-#include "GameFramework/InputSettings.h"
-#include "Engine.h"
+#include <GameFramework/InputSettings.h>
+#include <Engine.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareMenuManager"

--- a/Source/HeliumRain/Player/FlareMenuManager.h
+++ b/Source/HeliumRain/Player/FlareMenuManager.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 #include "../UI/FlareUITypes.h"
-#include "GameFramework/HUD.h"
+#include <GameFramework/HUD.h>
 #include "FlareMenuManager.generated.h"
 
 

--- a/Source/HeliumRain/Player/FlareMenuPawn.cpp
+++ b/Source/HeliumRain/Player/FlareMenuPawn.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareMenuPawn.h"
+#include "HeliumRain/Player/FlareMenuPawn.h"
 #include "../Flare.h"
-#include "FlarePlayerController.h"
-#include "FlareHUD.h"
+#include "HeliumRain/Player/FlarePlayerController.h"
+#include "HeliumRain/Player/FlareHUD.h"
 #include "../Game/FlareGameUserSettings.h"
 
 

--- a/Source/HeliumRain/Player/FlarePlayerController.cpp
+++ b/Source/HeliumRain/Player/FlarePlayerController.cpp
@@ -1,12 +1,12 @@
 
-#include "FlarePlayerController.h"
+#include "HeliumRain/Player/FlarePlayerController.h"
 #include "../Flare.h"
 
-#include "FlareHUD.h"
-#include "FlareMenuPawn.h"
-#include "FlareSoundManager.h"
-#include "FlareMenuManager.h"
-#include "FlareCockpitManager.h"
+#include "HeliumRain/Player/FlareHUD.h"
+#include "HeliumRain/Player/FlareMenuPawn.h"
+#include "HeliumRain/Player/FlareSoundManager.h"
+#include "HeliumRain/Player/FlareMenuManager.h"
+#include "HeliumRain/Player/FlareCockpitManager.h"
 
 #include "../UI/Menus/FlareOrbitalMenu.h"
 #include "../UI/Menus/FlareSectorMenu.h"
@@ -28,20 +28,20 @@
 #include "../Spacecrafts/FlarePilotHelper.h"
 #include "../Spacecrafts/FlareTurretPilot.h"
 
-#include "GameFramework/InputSettings.h"
+#include <GameFramework/InputSettings.h>
 
-#include "Engine/PostProcessVolume.h"
-#include "Engine/Canvas.h"
-#include "Engine.h"
-#include "EngineUtils.h"
+#include <Engine/PostProcessVolume.h>
+#include <Engine/Canvas.h>
+#include <Engine.h>
+#include <EngineUtils.h>
 
-#include "OnlineSubsystem.h"
-#include "OnlineStats.h"
-#include "OnlineIdentityInterface.h"
-#include "OnlineAchievementsInterface.h"
+#include <OnlineSubsystem.h>
+#include <OnlineStats.h>
+#include <Interfaces/OnlineIdentityInterface.h>
+#include <Interfaces/OnlineAchievementsInterface.h>
 
-#include "HighResScreenshot.h"
-#include "SceneViewport.h"
+#include <HighResScreenshot.h>
+#include <Slate/SceneViewport.h>
 
 DECLARE_CYCLE_STAT(TEXT("FlarePlayerTick ControlGroups"), STAT_FlarePlayerTick_ControlGroups, STATGROUP_Flare);
 DECLARE_CYCLE_STAT(TEXT("FlarePlayerTick Battle"), STAT_FlarePlayerTick_Battle, STATGROUP_Flare);

--- a/Source/HeliumRain/Player/FlarePlayerController.h
+++ b/Source/HeliumRain/Player/FlarePlayerController.h
@@ -4,7 +4,7 @@
 #include "../Game/FlareSaveGame.h"
 #include "../Game/FlareGameTypes.h"
 #include "../UI/FlareUITypes.h"
-#include "Engine/CanvasRenderTarget2D.h"
+#include <Engine/CanvasRenderTarget2D.h>
 #include "FlarePlayerController.generated.h"
 
 

--- a/Source/HeliumRain/Player/FlareSoundManager.cpp
+++ b/Source/HeliumRain/Player/FlareSoundManager.cpp
@@ -1,14 +1,14 @@
 
-#include "FlareSoundManager.h"
+#include "HeliumRain/Player/FlareSoundManager.h"
 #include "../Flare.h"
 
-#include "FlareMenuManager.h"
-#include "FlarePlayerController.h"
+#include "HeliumRain/Player/FlareMenuManager.h"
+#include "HeliumRain/Player/FlarePlayerController.h"
 
 #include "../Spacecrafts/FlareSpacecraft.h"
 #include "../Spacecrafts/FlareOrbitalEngine.h"
 
-#include "AudioDevice.h"
+#include <AudioDevice.h>
 
 
 #define LOCTEXT_NAMESPACE "UFlareSoundManager"

--- a/Source/HeliumRain/Player/FlareSoundManager.h
+++ b/Source/HeliumRain/Player/FlareSoundManager.h
@@ -2,7 +2,7 @@
 
 #include "../Flare.h"
 
-#include "Sound/SoundCue.h"
+#include <Sound/SoundCue.h>
 
 #include "FlareSoundManager.generated.h"
 

--- a/Source/HeliumRain/Quests/FlareCatalogQuest.cpp
+++ b/Source/HeliumRain/Quests/FlareCatalogQuest.cpp
@@ -1,10 +1,10 @@
 
-#include "FlareCatalogQuest.h"
-#include "Flare.h"
+#include "HeliumRain/Quests/FlareCatalogQuest.h"
+#include "HeliumRain/Flare.h"
 #include "../Game/FlareGame.h"
-#include "FlareQuestCondition.h"
-#include "FlareQuestAction.h"
-#include "FlareQuestStep.h"
+#include "HeliumRain/Quests/FlareQuestCondition.h"
+#include "HeliumRain/Quests/FlareQuestAction.h"
+#include "HeliumRain/Quests/FlareQuestStep.h"
 #include "../Data/FlareQuestCatalogEntry.h"
 
 #define LOCTEXT_NAMESPACE "FlareCatalogQuest"

--- a/Source/HeliumRain/Quests/FlareCatalogQuest.h
+++ b/Source/HeliumRain/Quests/FlareCatalogQuest.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareQuest.h"
+#include "HeliumRain/Quests/FlareQuest.h"
 #include "../Data/FlareQuestCatalogEntry.h"
 #include "FlareCatalogQuest.generated.h"
 

--- a/Source/HeliumRain/Quests/FlareMeteorite.cpp
+++ b/Source/HeliumRain/Quests/FlareMeteorite.cpp
@@ -1,12 +1,12 @@
 
-#include "FlareMeteorite.h"
+#include "HeliumRain/Quests/FlareMeteorite.h"
 #include "../Flare.h"
 #include "../Game/FlareGame.h"
 #include "../Game/FlareGameTools.h"
 #include "../Data/FlareMeteoriteCatalog.h"
 #include "../Player/FlarePlayerController.h"
 
-#include "Components/StaticMeshComponent.h"
+#include <Components/StaticMeshComponent.h>
 
 #define LOCTEXT_NAMESPACE "FlareMeteorite"
 

--- a/Source/HeliumRain/Quests/FlareQuest.cpp
+++ b/Source/HeliumRain/Quests/FlareQuest.cpp
@@ -1,6 +1,6 @@
 
-#include "FlareQuest.h"
-#include "Flare.h"
+#include "HeliumRain/Quests/FlareQuest.h"
+#include "HeliumRain/Flare.h"
 
 #include "../Game/FlareGame.h"
 #include "../Game/FlareGameTools.h"
@@ -8,11 +8,11 @@
 #include "../Player/FlareMenuManager.h"
 #include "../Player/FlarePlayerController.h"
 
-#include "FlareQuestStep.h"
-#include "FlareQuestCondition.h"
-#include "FlareQuestAction.h"
+#include "HeliumRain/Quests/FlareQuestStep.h"
+#include "HeliumRain/Quests/FlareQuestCondition.h"
+#include "HeliumRain/Quests/FlareQuestAction.h"
 
-#include "GameFramework/InputSettings.h"
+#include <GameFramework/InputSettings.h>
 
 #define LOCTEXT_NAMESPACE "FlareQuest"
 

--- a/Source/HeliumRain/Quests/FlareQuest.h
+++ b/Source/HeliumRain/Quests/FlareQuest.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareQuestManager.h"
+#include "HeliumRain/Quests/FlareQuestManager.h"
 
 #include "FlareQuest.generated.h"
 

--- a/Source/HeliumRain/Quests/FlareQuestAction.cpp
+++ b/Source/HeliumRain/Quests/FlareQuestAction.cpp
@@ -1,6 +1,6 @@
 
-#include "FlareQuestAction.h"
-#include "Flare.h"
+#include "HeliumRain/Quests/FlareQuestAction.h"
+#include "HeliumRain/Flare.h"
 
 #include "../Game/FlareGame.h"
 #include "../Game/FlareCompany.h"
@@ -11,7 +11,7 @@
 
 #include "../Player/FlarePlayerController.h"
 
-#include "FlareQuest.h"
+#include "HeliumRain/Quests/FlareQuest.h"
 
 
 #define LOCTEXT_NAMESPACE "FlareQuestAction"

--- a/Source/HeliumRain/Quests/FlareQuestCondition.cpp
+++ b/Source/HeliumRain/Quests/FlareQuestCondition.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareQuestCondition.h"
-#include "Flare.h"
-#include "FlareQuest.h"
+#include "HeliumRain/Quests/FlareQuestCondition.h"
+#include "HeliumRain/Flare.h"
+#include "HeliumRain/Quests/FlareQuest.h"
 
 #include "../Data/FlareSpacecraftCatalog.h"
 

--- a/Source/HeliumRain/Quests/FlareQuestCondition.h
+++ b/Source/HeliumRain/Quests/FlareQuestCondition.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareQuestManager.h"
+#include "HeliumRain/Quests/FlareQuestManager.h"
 #include "FlareQuestCondition.generated.h"
 
 class UFlareQuest;

--- a/Source/HeliumRain/Quests/FlareQuestGenerator.cpp
+++ b/Source/HeliumRain/Quests/FlareQuestGenerator.cpp
@@ -1,6 +1,6 @@
 
-#include "FlareQuestGenerator.h"
-#include "Flare.h"
+#include "HeliumRain/Quests/FlareQuestGenerator.h"
+#include "HeliumRain/Flare.h"
 
 #include "../Data/FlareResourceCatalog.h"
 
@@ -13,12 +13,12 @@
 
 #include "../Player/FlarePlayerController.h"
 
-#include "FlareQuestManager.h"
-#include "FlareQuestCondition.h"
-#include "FlareQuest.h"
-#include "FlareQuestStep.h"
-#include "FlareQuestAction.h"
-#include "QuestCatalog/FlareTutorialQuest.h"
+#include "HeliumRain/Quests/FlareQuestManager.h"
+#include "HeliumRain/Quests/FlareQuestCondition.h"
+#include "HeliumRain/Quests/FlareQuest.h"
+#include "HeliumRain/Quests/FlareQuestStep.h"
+#include "HeliumRain/Quests/FlareQuestAction.h"
+#include "HeliumRain/Quests/QuestCatalog/FlareTutorialQuest.h"
 
 #define LOCTEXT_NAMESPACE "FlareQuestGenerator"
 

--- a/Source/HeliumRain/Quests/FlareQuestGenerator.h
+++ b/Source/HeliumRain/Quests/FlareQuestGenerator.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Game/FlareGameTypes.h"
-#include "FlareQuest.h"
-#include "FlareQuestManager.h"
+#include "HeliumRain/Game/FlareGameTypes.h"
+#include "HeliumRain/Quests/FlareQuest.h"
+#include "HeliumRain/Quests/FlareQuestManager.h"
 #include "FlareQuestGenerator.generated.h"
 
 

--- a/Source/HeliumRain/Quests/FlareQuestManager.cpp
+++ b/Source/HeliumRain/Quests/FlareQuestManager.cpp
@@ -1,14 +1,14 @@
 
-#include "FlareQuestManager.h"
-#include "Flare.h"
+#include "HeliumRain/Quests/FlareQuestManager.h"
+#include "HeliumRain/Flare.h"
 #include "../Game/FlareGame.h"
 #include "../Data/FlareQuestCatalog.h"
 #include "../Data/FlareQuestCatalogEntry.h"
 #include "../Player/FlarePlayerController.h"
-#include "FlareQuestGenerator.h"
-#include "FlareCatalogQuest.h"
-#include "QuestCatalog/FlareTutorialQuest.h"
-#include "QuestCatalog/FlareHistoryQuest.h"
+#include "HeliumRain/Quests/FlareQuestGenerator.h"
+#include "HeliumRain/Quests/FlareCatalogQuest.h"
+#include "HeliumRain/Quests/QuestCatalog/FlareTutorialQuest.h"
+#include "HeliumRain/Quests/QuestCatalog/FlareHistoryQuest.h"
 
 #define LOCTEXT_NAMESPACE "FlareQuestManager"
 

--- a/Source/HeliumRain/Quests/FlareQuestStep.cpp
+++ b/Source/HeliumRain/Quests/FlareQuestStep.cpp
@@ -1,10 +1,10 @@
 
-#include "FlareQuestStep.h"
-#include "Flare.h"
+#include "HeliumRain/Quests/FlareQuestStep.h"
+#include "HeliumRain/Flare.h"
 
-#include "FlareQuest.h"
-#include "FlareQuestCondition.h"
-#include "FlareQuestAction.h"
+#include "HeliumRain/Quests/FlareQuest.h"
+#include "HeliumRain/Quests/FlareQuestCondition.h"
+#include "HeliumRain/Quests/FlareQuestAction.h"
 
 #include "../Player/FlarePlayerController.h"
 

--- a/Source/HeliumRain/Quests/FlareQuestStep.h
+++ b/Source/HeliumRain/Quests/FlareQuestStep.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareQuestCondition.h"
+#include "HeliumRain/Quests/FlareQuestCondition.h"
 #include "FlareQuestStep.generated.h"
 
 class UFlareQuest;

--- a/Source/HeliumRain/Quests/QuestCatalog/FlareHistoryQuest.cpp
+++ b/Source/HeliumRain/Quests/QuestCatalog/FlareHistoryQuest.cpp
@@ -1,23 +1,23 @@
 
-#include "FlareHistoryQuest.h"
-#include "Flare.h"
+#include "HeliumRain/Quests/QuestCatalog/FlareHistoryQuest.h"
+#include "HeliumRain/Flare.h"
 
-#include "Data/FlareResourceCatalog.h"
-#include "Data/FlareSpacecraftCatalog.h"
+#include "HeliumRain/Data/FlareResourceCatalog.h"
+#include "HeliumRain/Data/FlareSpacecraftCatalog.h"
 
-#include "Economy/FlareCargoBay.h"
+#include "HeliumRain/Economy/FlareCargoBay.h"
 
-#include "Game/FlareGame.h"
-#include "Game/FlareGameTools.h"
-#include "Game/FlareScenarioTools.h"
+#include "HeliumRain/Game/FlareGame.h"
+#include "HeliumRain/Game/FlareGameTools.h"
+#include "HeliumRain/Game/FlareScenarioTools.h"
 
-#include "Player/FlarePlayerController.h"
+#include "HeliumRain/Player/FlarePlayerController.h"
 
 #include "../FlareQuestCondition.h"
 #include "../FlareQuestStep.h"
 #include "../FlareQuestAction.h"
 
-#include "FlareTutorialQuest.h"
+#include "HeliumRain/Quests/QuestCatalog/FlareTutorialQuest.h"
 
 
 #define LOCTEXT_NAMESPACE "FlareHistotyQuest"

--- a/Source/HeliumRain/Quests/QuestCatalog/FlareTutorialQuest.cpp
+++ b/Source/HeliumRain/Quests/QuestCatalog/FlareTutorialQuest.cpp
@@ -1,6 +1,6 @@
-#include "FlareTutorialQuest.h"
+#include "HeliumRain/Quests/QuestCatalog/FlareTutorialQuest.h"
 
-#include "Flare.h"
+#include "HeliumRain/Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../FlareQuestCondition.h"
 #include "../FlareQuestAction.h"

--- a/Source/HeliumRain/Spacecrafts/FlareBomb.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareBomb.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareBomb.h"
+#include "HeliumRain/Spacecrafts/FlareBomb.h"
 #include "../Flare.h"
 
 #include "../Game/FlareAsteroid.h"
@@ -9,13 +9,13 @@
 
 #include "../Player/FlarePlayerController.h"
 
-#include "FlareWeapon.h"
-#include "FlareBombComponent.h"
-#include "FlareSpacecraft.h"
-#include "FlareShell.h"
+#include "HeliumRain/Spacecrafts/FlareWeapon.h"
+#include "HeliumRain/Spacecrafts/FlareBombComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareShell.h"
 
-#include "Components/DecalComponent.h"
-#include "Components/StaticMeshComponent.h"
+#include <Components/DecalComponent.h>
+#include <Components/StaticMeshComponent.h>
 
 #define LOCTEXT_NAMESPACE "FlareBomb"
 

--- a/Source/HeliumRain/Spacecrafts/FlareBomb.h
+++ b/Source/HeliumRain/Spacecrafts/FlareBomb.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareWeapon.h"
+#include "HeliumRain/Spacecrafts/FlareWeapon.h"
 #include "../Flare.h"
 #include "FlareBomb.generated.h"
 

--- a/Source/HeliumRain/Spacecrafts/FlareBombComponent.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareBombComponent.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareBombComponent.h"
+#include "HeliumRain/Spacecrafts/FlareBombComponent.h"
 #include "../Flare.h"
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Spacecrafts/FlareBombComponent.h
+++ b/Source/HeliumRain/Spacecrafts/FlareBombComponent.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 #include "FlareBombComponent.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareEngine.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareEngine.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareEngine.h"
+#include "HeliumRain/Spacecrafts/FlareEngine.h"
 #include "../Flare.h"
-#include "FlareSpacecraft.h"
-#include "FlareOrbitalEngine.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareOrbitalEngine.h"
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Spacecrafts/FlareEngine.h
+++ b/Source/HeliumRain/Spacecrafts/FlareEngine.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 #include "FlareEngine.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareInternalComponent.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareInternalComponent.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareInternalComponent.h"
+#include "HeliumRain/Spacecrafts/FlareInternalComponent.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareInternalComponent.h
+++ b/Source/HeliumRain/Spacecrafts/FlareInternalComponent.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 #include "FlareInternalComponent.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareOrbitalEngine.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareOrbitalEngine.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareOrbitalEngine.h"
+#include "HeliumRain/Spacecrafts/FlareOrbitalEngine.h"
 #include "../Flare.h"
-#include "FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Spacecrafts/FlareOrbitalEngine.h
+++ b/Source/HeliumRain/Spacecrafts/FlareOrbitalEngine.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareEngine.h"
+#include "HeliumRain/Spacecrafts/FlareEngine.h"
 #include "FlareOrbitalEngine.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlarePilotHelper.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlarePilotHelper.cpp
@@ -1,17 +1,17 @@
 
-#include "FlarePilotHelper.h"
+#include "HeliumRain/Spacecrafts/FlarePilotHelper.h"
 #include "../Flare.h"
 #include "../Game/FlareCompany.h"
 #include "../Game/FlareSector.h"
 #include "../Game/FlareGame.h"
 #include "../Game/FlareCollider.h"
-#include "FlareRCS.h"
-#include "FlareOrbitalEngine.h"
-#include "FlareWeapon.h"
-#include "FlareShipPilot.h"
+#include "HeliumRain/Spacecrafts/FlareRCS.h"
+#include "HeliumRain/Spacecrafts/FlareOrbitalEngine.h"
+#include "HeliumRain/Spacecrafts/FlareWeapon.h"
+#include "HeliumRain/Spacecrafts/FlareShipPilot.h"
 #include "../Quests/FlareMeteorite.h"
 
-#include "Components/StaticMeshComponent.h"
+#include <Components/StaticMeshComponent.h>
 
 
 DECLARE_CYCLE_STAT(TEXT("PilotHelper CheckFriendlyFire"), STAT_PilotHelper_CheckFriendlyFire, STATGROUP_Flare);

--- a/Source/HeliumRain/Spacecrafts/FlarePilotHelper.h
+++ b/Source/HeliumRain/Spacecrafts/FlarePilotHelper.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "EngineMinimal.h"
+#include <EngineMinimal.h>
 
 class UFlareCompany;
 class UFlareSector;

--- a/Source/HeliumRain/Spacecrafts/FlareRCS.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareRCS.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareRCS.h"
+#include "HeliumRain/Spacecrafts/FlareRCS.h"
 #include "../Flare.h"
-#include "FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Spacecrafts/FlareRCS.h
+++ b/Source/HeliumRain/Spacecrafts/FlareRCS.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareEngine.h"
+#include "HeliumRain/Spacecrafts/FlareEngine.h"
 #include "FlareRCS.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareShell.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareShell.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareShell.h"
+#include "HeliumRain/Spacecrafts/FlareShell.h"
 #include "../Flare.h"
 
-#include "FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
 
 #include "../Game/FlareGame.h"
 #include "../Game/FlareGameTypes.h"
@@ -10,9 +10,9 @@
 
 #include "../Player/FlarePlayerController.h"
 
-#include "Components/DecalComponent.h"
-#include "Components/StaticMeshComponent.h"
-#include "Engine.h"
+#include <Components/DecalComponent.h>
+#include <Components/StaticMeshComponent.h>
+#include <Engine.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Spacecrafts/FlareShell.h
+++ b/Source/HeliumRain/Spacecrafts/FlareShell.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareWeapon.h"
+#include "HeliumRain/Spacecrafts/FlareWeapon.h"
 #include "FlareShell.generated.h"
 
 UCLASS(Blueprintable, ClassGroup = (Flare, Ship), meta = (BlueprintSpawnableComponent))

--- a/Source/HeliumRain/Spacecrafts/FlareShipPilot.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareShipPilot.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareShipPilot.h"
+#include "HeliumRain/Spacecrafts/FlareShipPilot.h"
 #include "../Flare.h"
 
-#include "FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
 
 #include "../Data/FlareSpacecraftComponentsCatalog.h"
 

--- a/Source/HeliumRain/Spacecrafts/FlareShipPilot.h
+++ b/Source/HeliumRain/Spacecrafts/FlareShipPilot.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "FlareSpacecraftTypes.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftTypes.h"
 #include "../Game/FlareGameTypes.h"
-#include "FlarePilotHelper.h"
+#include "HeliumRain/Spacecrafts/FlarePilotHelper.h"
 #include "FlareShipPilot.generated.h"
 
 class UFlareCompany;

--- a/Source/HeliumRain/Spacecrafts/FlareSimulatedSpacecraft.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareSimulatedSpacecraft.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSimulatedSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareSimulatedSpacecraft.h"
 #include "../Flare.h"
 
 #include "../Game/FlareSimulatedSector.h"
@@ -18,9 +18,9 @@
 #include "../Data/FlareSpacecraftCatalog.h"
 #include "../Data/FlareSpacecraftComponentsCatalog.h"
 
-#include "Subsystems/FlareSpacecraftDockingSystem.h"
-#include "Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
-#include "Subsystems/FlareSimulatedSpacecraftWeaponsSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDockingSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftWeaponsSystem.h"
 
 
 #define LOCTEXT_NAMESPACE "FlareSimulatedSpacecraft"

--- a/Source/HeliumRain/Spacecrafts/FlareSimulatedSpacecraft.h
+++ b/Source/HeliumRain/Spacecrafts/FlareSimulatedSpacecraft.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "Object.h"
+#include <UObject/Object.h>
 #include "../Game/FlareSimulatedSector.h"
 #include "../Economy/FlareCargoBay.h"
 #include "../Economy/FlareResource.h"
-#include "Subsystems/FlareSpacecraftDockingSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDockingSystem.h"
 #include "FlareSimulatedSpacecraft.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraft.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraft.cpp
@@ -1,16 +1,16 @@
 
-#include "FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
 #include "../Flare.h"
 
-#include "FlareOrbitalEngine.h"
-#include "FlareRCS.h"
-#include "FlareWeapon.h"
-#include "FlareTurret.h"
-#include "FlareShipPilot.h"
-#include "FlarePilotHelper.h"
-#include "FlareInternalComponent.h"
+#include "HeliumRain/Spacecrafts/FlareOrbitalEngine.h"
+#include "HeliumRain/Spacecrafts/FlareRCS.h"
+#include "HeliumRain/Spacecrafts/FlareWeapon.h"
+#include "HeliumRain/Spacecrafts/FlareTurret.h"
+#include "HeliumRain/Spacecrafts/FlareShipPilot.h"
+#include "HeliumRain/Spacecrafts/FlarePilotHelper.h"
+#include "HeliumRain/Spacecrafts/FlareInternalComponent.h"
 
-#include "Particles/ParticleSystemComponent.h"
+#include <Particles/ParticleSystemComponent.h>
 
 #include "../Data/FlareSpacecraftCatalog.h"
 #include "../Data/FlareSpacecraftComponentsCatalog.h"
@@ -28,12 +28,12 @@
 
 #include "../UI/Menus/FlareShipMenu.h"
 
-#include "Components/DecalComponent.h"
-#include "Kismet/KismetMathLibrary.h"
-#include "Engine/CanvasRenderTarget2D.h"
-#include "Engine/Canvas.h"
-#include "EngineUtils.h"
-#include "Engine.h"
+#include <Components/DecalComponent.h>
+#include <Kismet/KismetMathLibrary.h>
+#include <Engine/CanvasRenderTarget2D.h>
+#include <Engine/Canvas.h>
+#include <EngineUtils.h>
+#include <Engine.h>
 
 
 DECLARE_CYCLE_STAT(TEXT("FlareSpacecraft Systems"), STAT_FlareSpacecraft_Systems, STATGROUP_Flare);

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraft.h
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraft.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#include "FlareSpacecraftPawn.h"
-#include "FlareWeapon.h"
-#include "FlareSpacecraftComponent.h"
-#include "FlareSpacecraftSpinningComponent.h"
-#include "Subsystems/FlareSpacecraftDamageSystem.h"
-#include "Subsystems/FlareSpacecraftNavigationSystem.h"
-#include "Subsystems/FlareSpacecraftDockingSystem.h"
-#include "Subsystems/FlareSpacecraftWeaponsSystem.h"
-#include "FlareSpacecraftStateManager.h"
-#include "FlarePilotHelper.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftPawn.h"
+#include "HeliumRain/Spacecrafts/FlareWeapon.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftSpinningComponent.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDamageSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftNavigationSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDockingSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystem.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftStateManager.h"
+#include "HeliumRain/Spacecrafts/FlarePilotHelper.h"
 #include "FlareSpacecraft.generated.h"
 
 class UFlareShipPilot;

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftComponent.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftComponent.cpp
@@ -1,9 +1,9 @@
 
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 #include "../Flare.h"
 
-#include "FlareSpacecraft.h"
-#include "FlareInternalComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareInternalComponent.h"
 
 #include "../Data/FlareCustomizationCatalog.h"
 #include "../Data/FlareSpacecraftComponentsCatalog.h"
@@ -13,10 +13,10 @@
 #include "../Player/FlareMenuPawn.h"
 #include "../Player/FlarePlayerController.h"
 
-#include "FlareOrbitalEngine.h"
+#include "HeliumRain/Spacecrafts/FlareOrbitalEngine.h"
 
-#include "StaticMeshResources.h"
-#include "PhysicsEngine/BodySetup.h"
+#include <StaticMeshResources.h>
+#include <PhysicsEngine/BodySetup.h>
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftComponent.h
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "FlareSpacecraftTypes.h"
-#include "FlareTurretPilot.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftTypes.h"
+#include "HeliumRain/Spacecrafts/FlareTurretPilot.h"
 #include "FlareSpacecraftComponent.generated.h"
 
 class AFlareSpacecraftPawn;

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftPawn.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftPawn.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareSpacecraftPawn.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftPawn.h"
 #include "../Flare.h"
-#include "FlareRCS.h"
+#include "HeliumRain/Spacecrafts/FlareRCS.h"
 #include "../Player/FlarePlayerController.h"
 #include "../Game/FlareGame.h"
 

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftPawn.h
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftPawn.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Game/FlareCompany.h"
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 #include "FlareSpacecraftPawn.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftSpinningComponent.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftSpinningComponent.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareSpacecraftSpinningComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftSpinningComponent.h"
 #include "../Flare.h"
-#include "FlareSpacecraft.h"
-#include "Subsystems/FlareSpacecraftDamageSystem.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDamageSystem.h"
 #include "../Game/FlareGame.h"
 #include "../Game/FlarePlanetarium.h"
 

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftSpinningComponent.h
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftSpinningComponent.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 #include "FlareSpacecraftSpinningComponent.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftStateManager.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftStateManager.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftStateManager.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftStateManager.h"
 #include "../Flare.h"
 
 #include "../Game/FlareGameUserSettings.h"
@@ -7,12 +7,12 @@
 #include "../Player/FlarePlayerController.h"
 #include "../Player/FlareMenuManager.h"
 #include "../Player/FlareHUD.h"
-#include "FlareShipPilot.h"
-#include "FlarePilotHelper.h"
-#include "FlareSpacecraft.h"
-#include "FlareShipPilot.h"
+#include "HeliumRain/Spacecrafts/FlareShipPilot.h"
+#include "HeliumRain/Spacecrafts/FlarePilotHelper.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareShipPilot.h"
 
-#include "Engine.h"
+#include <Engine.h>
 
 
 DECLARE_CYCLE_STAT(TEXT("FlareStateManager Tick"), STAT_FlareStateManager_Tick, STATGROUP_Flare);

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftStateManager.h
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftStateManager.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "FlareSpacecraftTypes.h"
-#include "Subsystems/FlareSimulatedSpacecraftWeaponsSystem.h"
-#include "Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftTypes.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftWeaponsSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
 #include "FlareSpacecraftStateManager.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftSubComponent.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftSubComponent.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareSpacecraftSubComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftSubComponent.h"
 #include "../Flare.h"
-#include "FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
 
 
 /*----------------------------------------------------

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftSubComponent.h
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftSubComponent.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 #include "FlareSpacecraftSubComponent.generated.h"
 
 UCLASS(Blueprintable, ClassGroup = (Flare, Ship), meta = (BlueprintSpawnableComponent))

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftTypes.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftTypes.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftTypes.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftTypes.h"
 #include "../Flare.h"
 #include "../Data/FlareFactoryCatalogEntry.h"
 

--- a/Source/HeliumRain/Spacecrafts/FlareSpacecraftTypes.h
+++ b/Source/HeliumRain/Spacecrafts/FlareSpacecraftTypes.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "EngineMinimal.h"
-#include "Styling/SlateBrush.h"
-#include "Sound/SoundCue.h"
+#include <EngineMinimal.h>
+#include <Styling/SlateBrush.h>
+#include <Sound/SoundCue.h>
 #include "FlareSpacecraftTypes.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareStationConnector.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareStationConnector.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareStationConnector.h"
+#include "HeliumRain/Spacecrafts/FlareStationConnector.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareStationConnector.h
+++ b/Source/HeliumRain/Spacecrafts/FlareStationConnector.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 #include "FlareStationConnector.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareStationDock.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareStationDock.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareStationDock.h"
+#include "HeliumRain/Spacecrafts/FlareStationDock.h"
 #include "../Flare.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/FlareTurret.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareTurret.cpp
@@ -1,9 +1,9 @@
 
-#include "FlareTurret.h"
+#include "HeliumRain/Spacecrafts/FlareTurret.h"
 #include "../Flare.h"
-#include "FlareSpacecraft.h"
-#include "FlareShell.h"
-#include "FlareSpacecraftSubComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareShell.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftSubComponent.h"
 
 DECLARE_CYCLE_STAT(TEXT("FlareTurret Tick"), STAT_FlareTurret_Tick, STATGROUP_Flare);
 DECLARE_CYCLE_STAT(TEXT("FlareTurret Update"), STAT_FlareTurret_Update, STATGROUP_Flare);

--- a/Source/HeliumRain/Spacecrafts/FlareTurret.h
+++ b/Source/HeliumRain/Spacecrafts/FlareTurret.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "FlareSpacecraftComponent.h"
-#include "FlareWeapon.h"
-#include "FlareTurretPilot.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareWeapon.h"
+#include "HeliumRain/Spacecrafts/FlareTurretPilot.h"
 #include "FlareTurret.generated.h"
 
 class UFlareSpacecraftSubComponent;

--- a/Source/HeliumRain/Spacecrafts/FlareTurretPilot.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareTurretPilot.cpp
@@ -1,12 +1,12 @@
 
-#include "FlareTurretPilot.h"
+#include "HeliumRain/Spacecrafts/FlareTurretPilot.h"
 #include "../Flare.h"
 
-#include "FlarePilotHelper.h"
-#include "FlareTurret.h"
-#include "FlareRCS.h"
-#include "FlareSpacecraft.h"
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlarePilotHelper.h"
+#include "HeliumRain/Spacecrafts/FlareTurret.h"
+#include "HeliumRain/Spacecrafts/FlareRCS.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 
 #include "../Player/FlarePlayerController.h"
 #include "../Game/FlareGame.h"

--- a/Source/HeliumRain/Spacecrafts/FlareTurretPilot.h
+++ b/Source/HeliumRain/Spacecrafts/FlareTurretPilot.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Game/FlareGameTypes.h"
-#include "FlarePilotHelper.h"
+#include "HeliumRain/Spacecrafts/FlarePilotHelper.h"
 #include "FlareTurretPilot.generated.h"
 
 class UFlareTurret;

--- a/Source/HeliumRain/Spacecrafts/FlareWeapon.cpp
+++ b/Source/HeliumRain/Spacecrafts/FlareWeapon.cpp
@@ -1,18 +1,18 @@
 
-#include "FlareWeapon.h"
+#include "HeliumRain/Spacecrafts/FlareWeapon.h"
 #include "../Flare.h"
 
-#include "FlareSpacecraftTypes.h"
-#include "FlareSpacecraft.h"
-#include "FlareShell.h"
-#include "FlareBomb.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftTypes.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraft.h"
+#include "HeliumRain/Spacecrafts/FlareShell.h"
+#include "HeliumRain/Spacecrafts/FlareBomb.h"
 
 #include "../Game/FlareGame.h"
 #include "../Game/FlareSkirmishManager.h"
 
 #include "../Player/FlarePlayerController.h"
 
-#include "Engine/StaticMeshSocket.h"
+#include <Engine/StaticMeshSocket.h>
 
 DECLARE_CYCLE_STAT(TEXT("FlareWeapon Firing"), STAT_Weapon_Firing, STATGROUP_Flare);
 DECLARE_CYCLE_STAT(TEXT("FlareWeapon FireGun"), STAT_Weapon_FireGun, STATGROUP_Flare);

--- a/Source/HeliumRain/Spacecrafts/FlareWeapon.h
+++ b/Source/HeliumRain/Spacecrafts/FlareWeapon.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareSpacecraftComponent.h"
+#include "HeliumRain/Spacecrafts/FlareSpacecraftComponent.h"
 #include "FlareWeapon.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.cpp
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSimulatedSpacecraftDamageSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
 #include "../../Flare.h"
 
 #include "../FlareSimulatedSpacecraft.h"
@@ -15,7 +15,7 @@
 #include "../../Game/FlareGameTools.h"
 #include "../../Game/FlareScenarioTools.h"
 
-#include "FlareSimulatedSpacecraftWeaponsSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftWeaponsSystem.h"
 
 
 DECLARE_CYCLE_STAT(TEXT("FlareSimulatedDamageSystem UpdateSubsystemHealth"), STAT_FlareSimulatedDamageSystem_UpdateSubsystemHealth, STATGROUP_Flare);

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftWeaponsSystem.cpp
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftWeaponsSystem.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSimulatedSpacecraftWeaponsSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftWeaponsSystem.h"
 #include "../../Flare.h"
 
 #include "../../Data/FlareSpacecraftComponentsCatalog.h"
@@ -10,7 +10,7 @@
 #include "../FlareSpacecraftComponent.h"
 #include "../FlareSimulatedSpacecraft.h"
 
-#include "FlareSimulatedSpacecraftDamageSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
 
 
 #define LOCTEXT_NAMESPACE "FlareSimulatedSpacecraftWeaponsSystem"

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftWeaponsSystem.h
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftWeaponsSystem.h
@@ -2,7 +2,7 @@
 
 #include "../FlareSpacecraftTypes.h"
 #include "../FlareSimulatedSpacecraft.h"
-#include "FlareSpacecraftWeaponsSystemInterface.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystemInterface.h"
 #include "FlareSimulatedSpacecraftWeaponsSystem.generated.h"
 
 /** Structure holding all data for a weapon group */

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDamageSystem.cpp
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDamageSystem.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftDamageSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDamageSystem.h"
 #include "../../Flare.h"
 
 #include "../FlareSpacecraft.h"
@@ -16,7 +16,7 @@
 #include "../FlareOrbitalEngine.h"
 #include "../FlareShell.h"
 
-#include "Engine/StaticMeshActor.h"
+#include <Engine/StaticMeshActor.h>
 
 DECLARE_CYCLE_STAT(TEXT("FlareDamageSystem Tick"), STAT_FlareDamageSystem_Tick, STATGROUP_Flare);
 

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDamageSystem.h
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDamageSystem.h
@@ -2,7 +2,7 @@
 
 #include "../FlareSpacecraftTypes.h"
 #include "../FlareSimulatedSpacecraft.h"
-#include "FlareSimulatedSpacecraftDamageSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSimulatedSpacecraftDamageSystem.h"
 #include "FlareSpacecraftDamageSystem.generated.h"
 
 

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDockingSystem.cpp
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDockingSystem.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftDockingSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDockingSystem.h"
 #include "../../Flare.h"
 
 #include "../FlareStationDock.h"

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftNavigationSystem.cpp
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftNavigationSystem.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftNavigationSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftNavigationSystem.h"
 #include "../../Flare.h"
 
 #include "../FlareSpacecraft.h"
@@ -9,7 +9,7 @@
 #include "../FlareOrbitalEngine.h"
 #include "../FlarePilotHelper.h"
 
-#include "PhysicsEngine/PhysicsConstraintComponent.h"
+#include <PhysicsEngine/PhysicsConstraintComponent.h>
 
 DECLARE_CYCLE_STAT(TEXT("FlareNavigationSystem Tick"), STAT_NavigationSystem_Tick, STATGROUP_Flare);
 DECLARE_CYCLE_STAT(TEXT("FlareNavigationSystem Manual"), STAT_NavigationSystem_Manual, STATGROUP_Flare);

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftNavigationSystem.h
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftNavigationSystem.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "FlareSpacecraftDockingSystem.h"
-#include "FlareSpacecraftDockingSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDockingSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftDockingSystem.h"
 #include "FlareSpacecraftNavigationSystem.generated.h"
 
 class AFlareSpacecraft;

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystem.cpp
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystem.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftWeaponsSystem.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystem.h"
 #include "../../Flare.h"
 
 #include "../FlareTurret.h"

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystem.h
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystem.h
@@ -2,7 +2,7 @@
 
 #include "../../Flare.h"
 #include "../FlarePilotHelper.h"
-#include "FlareSpacecraftWeaponsSystemInterface.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystemInterface.h"
 #include "FlareSpacecraftWeaponsSystem.generated.h"
 
 class AFlareSpacecraft;

--- a/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystemInterface.cpp
+++ b/Source/HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystemInterface.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftWeaponsSystemInterface.h"
+#include "HeliumRain/Spacecrafts/Subsystems/FlareSpacecraftWeaponsSystemInterface.h"
 #include "../../Flare.h"
 
 

--- a/Source/HeliumRain/UI/Components/FlareButton.cpp
+++ b/Source/HeliumRain/UI/Components/FlareButton.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareButton.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
 #include "../../Flare.h"
 #include "../../Player/FlareMenuManager.h"
 

--- a/Source/HeliumRain/UI/Components/FlareButton.h
+++ b/Source/HeliumRain/UI/Components/FlareButton.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "../../Flare.h"
-#include "Widgets/SCompoundWidget.h"
-#include "Fonts/SlateFontInfo.h"
-#include "Widgets/Text/STextBlock.h"
-#include "Widgets/Layout/SBorder.h"
-#include "Widgets/Input/SButton.h"
+#include <Widgets/SCompoundWidget.h>
+#include <Fonts/SlateFontInfo.h>
+#include <Widgets/Text/STextBlock.h>
+#include <Widgets/Layout/SBorder.h>
+#include <Widgets/Input/SButton.h>
 
 
 DECLARE_DELEGATE(FFlareButtonClicked)

--- a/Source/HeliumRain/UI/Components/FlareCargoInfo.cpp
+++ b/Source/HeliumRain/UI/Components/FlareCargoInfo.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareCargoInfo.h"
+#include "HeliumRain/UI/Components/FlareCargoInfo.h"
 
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"

--- a/Source/HeliumRain/UI/Components/FlareCargoInfo.h
+++ b/Source/HeliumRain/UI/Components/FlareCargoInfo.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../../Flare.h"
-#include "FlareButton.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
 
 
 class UFlareSimulatedSpacecraft;

--- a/Source/HeliumRain/UI/Components/FlareColorPanel.cpp
+++ b/Source/HeliumRain/UI/Components/FlareColorPanel.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareColorPanel.h"
+#include "HeliumRain/UI/Components/FlareColorPanel.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../../Player/FlareMenuPawn.h"

--- a/Source/HeliumRain/UI/Components/FlareCompanyFlag.cpp
+++ b/Source/HeliumRain/UI/Components/FlareCompanyFlag.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareCompanyFlag.h"
+#include "HeliumRain/UI/Components/FlareCompanyFlag.h"
 #include "../../Flare.h"
 #include "../../Player/FlarePlayerController.h"
 #include "../../Game/FlareCompany.h"

--- a/Source/HeliumRain/UI/Components/FlareCompanyInfo.cpp
+++ b/Source/HeliumRain/UI/Components/FlareCompanyInfo.cpp
@@ -1,12 +1,12 @@
 
-#include "FlareCompanyInfo.h"
+#include "HeliumRain/UI/Components/FlareCompanyInfo.h"
 #include "../../Flare.h"
 #include "../../Game/FlareCompany.h"
 #include "../../Game/FlareGameTools.h"
 #include "../../Game/AI/FlareAIBehavior.h"
 #include "../../Player/FlarePlayerController.h"
 #include "../FlareUITypes.h"
-#include "FlareButton.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
 
 
 #define LOCTEXT_NAMESPACE "FlareCompanyInfo"

--- a/Source/HeliumRain/UI/Components/FlareConfirmationBox.cpp
+++ b/Source/HeliumRain/UI/Components/FlareConfirmationBox.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareConfirmationBox.h"
+#include "HeliumRain/UI/Components/FlareConfirmationBox.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGameTools.h"
 #include "../../Player/FlarePlayerController.h"

--- a/Source/HeliumRain/UI/Components/FlareConfirmationOverlay.cpp
+++ b/Source/HeliumRain/UI/Components/FlareConfirmationOverlay.cpp
@@ -1,9 +1,9 @@
 
-#include "FlareConfirmationOverlay.h"
+#include "HeliumRain/UI/Components/FlareConfirmationOverlay.h"
 #include "../../Flare.h"
 #include "../../Player/FlareMenuManager.h"
 #include "../../Player/FlarePlayerController.h"
-#include "SBackgroundBlur.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 #define LOCTEXT_NAMESPACE "FlareConfirmationOverlay"
 

--- a/Source/HeliumRain/UI/Components/FlareDropList.h
+++ b/Source/HeliumRain/UI/Components/FlareDropList.h
@@ -4,8 +4,8 @@
 #include "../Components/FlareItemArray.h"
 #include "../Style/FlareStyleSet.h"
 
-#include "Runtime/Slate/Public/Widgets/Colors/SColorWheel.h"
-#include "SSimpleGradient.h"
+#include <Widgets/Colors/SColorWheel.h>
+#include <Widgets/Colors/SSimpleGradient.h>
 
 
 DECLARE_DELEGATE_OneParam(FFlareItemPicked, int32)

--- a/Source/HeliumRain/UI/Components/FlareFactoryInfo.cpp
+++ b/Source/HeliumRain/UI/Components/FlareFactoryInfo.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareFactoryInfo.h"
+#include "HeliumRain/UI/Components/FlareFactoryInfo.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../../Player/FlareMenuManager.h"
@@ -8,7 +8,7 @@
 #include "../../Economy/FlareCargoBay.h"
 #include "../../Data/FlareSpacecraftCatalog.h"
 #include "../FlareUITypes.h"
-#include "FlareButton.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
 
 #define LOCTEXT_NAMESPACE "FlareFactoryInfo"
 

--- a/Source/HeliumRain/UI/Components/FlareFleetInfo.cpp
+++ b/Source/HeliumRain/UI/Components/FlareFleetInfo.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareFleetInfo.h"
+#include "HeliumRain/UI/Components/FlareFleetInfo.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../../Game/FlareGameTools.h"

--- a/Source/HeliumRain/UI/Components/FlareItemArray.cpp
+++ b/Source/HeliumRain/UI/Components/FlareItemArray.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareItemArray.h"
+#include "HeliumRain/UI/Components/FlareItemArray.h"
 #include "../../Flare.h"
 #include "../Style/FlareStyleSet.h"
 

--- a/Source/HeliumRain/UI/Components/FlareItemArray.h
+++ b/Source/HeliumRain/UI/Components/FlareItemArray.h
@@ -2,7 +2,7 @@
 
 #include "../../Flare.h"
 #include "../Components/FlareButton.h"
-#include "Widgets/Layout/SGridPanel.h"
+#include <Widgets/Layout/SGridPanel.h>
 
 DECLARE_DELEGATE_OneParam(FFlareItemPicked, int32)
 DECLARE_DELEGATE_OneParam(FFlareColorPicked, FLinearColor)

--- a/Source/HeliumRain/UI/Components/FlareKeyBind.cpp
+++ b/Source/HeliumRain/UI/Components/FlareKeyBind.cpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FlareKeyBind.h"
+#include "HeliumRain/UI/Components/FlareKeyBind.h"
 #include "../../Flare.h"
 #include "../Style/FlareStyleSet.h"
 

--- a/Source/HeliumRain/UI/Components/FlareKeyBind.h
+++ b/Source/HeliumRain/UI/Components/FlareKeyBind.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../../Flare.h"
-#include "SlateBasics.h"
+#include <SlateBasics.h>
 
 class SFlareKeyBind;
 

--- a/Source/HeliumRain/UI/Components/FlareList.cpp
+++ b/Source/HeliumRain/UI/Components/FlareList.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareList.h"
+#include "HeliumRain/UI/Components/FlareList.h"
 #include "../../Flare.h"
 
 #include "../../Game/FlareGame.h"

--- a/Source/HeliumRain/UI/Components/FlareListItem.cpp
+++ b/Source/HeliumRain/UI/Components/FlareListItem.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareListItem.h"
+#include "HeliumRain/UI/Components/FlareListItem.h"
 #include "../../Flare.h"
 #include "../Style/FlareStyleSet.h"
 

--- a/Source/HeliumRain/UI/Components/FlareListItem.h
+++ b/Source/HeliumRain/UI/Components/FlareListItem.h
@@ -4,7 +4,7 @@
 #include "../Components/FlareButton.h"
 #include "../../Spacecrafts/FlareSimulatedSpacecraft.h"
 
-#include "Widgets/Views/STableRow.h"
+#include <Widgets/Views/STableRow.h>
 
 
 /** Interface storage structure */

--- a/Source/HeliumRain/UI/Components/FlareMainOverlay.cpp
+++ b/Source/HeliumRain/UI/Components/FlareMainOverlay.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareMainOverlay.h"
+#include "HeliumRain/UI/Components/FlareMainOverlay.h"
 #include "../../Flare.h"
 
 #include "../../Game/FlareGame.h"
@@ -12,12 +12,12 @@
 #include "../../Spacecrafts/FlareSpacecraft.h"
 
 #include "../FlareUITypes.h"
-#include "FlareButton.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
 
-#include "Runtime/Engine/Classes/Engine/UserInterfaceSettings.h"
-#include "Runtime/Engine/Classes/Engine/RendererSettings.h"
-#include "SBackgroundBlur.h"
-#include "Engine.h"
+#include <Engine/UserInterfaceSettings.h>
+#include <Engine/RendererSettings.h>
+#include <Widgets/Layout/SBackgroundBlur.h>
+#include <Engine.h>
 
 #define LOCTEXT_NAMESPACE "FlareMainOverlay"
 

--- a/Source/HeliumRain/UI/Components/FlareMainOverlay.h
+++ b/Source/HeliumRain/UI/Components/FlareMainOverlay.h
@@ -3,7 +3,7 @@
 #include "../../Flare.h"
 #include "../../Game/FlareGameTypes.h"
 #include "../FlareUITypes.h"
-#include "SBackgroundBlur.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 
 class AFlareMenuManager;

--- a/Source/HeliumRain/UI/Components/FlareNotification.cpp
+++ b/Source/HeliumRain/UI/Components/FlareNotification.cpp
@@ -1,14 +1,14 @@
 
-#include "FlareNotification.h"
+#include "HeliumRain/UI/Components/FlareNotification.h"
 #include "../../Flare.h"
 
 #include "../../Player/FlareMenuManager.h"
 #include "../../Player/FlarePlayerController.h"
 
-#include "FlareNotifier.h"
-#include "FlareButton.h"
+#include "HeliumRain/UI/Components/FlareNotifier.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
 
-#include "SBackgroundBlur.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareNotification"

--- a/Source/HeliumRain/UI/Components/FlareNotifier.cpp
+++ b/Source/HeliumRain/UI/Components/FlareNotifier.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareNotifier.h"
+#include "HeliumRain/UI/Components/FlareNotifier.h"
 #include "../../Flare.h"
 
 #include "../../Game/FlareGame.h"
@@ -7,10 +7,10 @@
 #include "../../Player/FlarePlayerController.h"
 #include "../../Quests/FlareQuest.h"
 
-#include "FlareButton.h"
-#include "FlareObjectiveInfo.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
+#include "HeliumRain/UI/Components/FlareObjectiveInfo.h"
 
-#include "SBackgroundBlur.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 #define LOCTEXT_NAMESPACE "FlareNotifier"
 

--- a/Source/HeliumRain/UI/Components/FlareObjectiveInfo.cpp
+++ b/Source/HeliumRain/UI/Components/FlareObjectiveInfo.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareObjectiveInfo.h"
+#include "HeliumRain/UI/Components/FlareObjectiveInfo.h"
 #include "../../Flare.h"
 #include "../../Player/FlarePlayerController.h"
 #include "../../Quests/FlareQuestStep.h"

--- a/Source/HeliumRain/UI/Components/FlarePartInfo.cpp
+++ b/Source/HeliumRain/UI/Components/FlarePartInfo.cpp
@@ -1,5 +1,5 @@
 
-#include "FlarePartInfo.h"
+#include "HeliumRain/UI/Components/FlarePartInfo.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGameTools.h"
 

--- a/Source/HeliumRain/UI/Components/FlarePlanetaryBox.cpp
+++ b/Source/HeliumRain/UI/Components/FlarePlanetaryBox.cpp
@@ -1,5 +1,5 @@
 
-#include "FlarePlanetaryBox.h"
+#include "HeliumRain/UI/Components/FlarePlanetaryBox.h"
 #include "../../Flare.h"
 #include "../Style/FlareStyleSet.h"
 

--- a/Source/HeliumRain/UI/Components/FlarePlanetaryBox.h
+++ b/Source/HeliumRain/UI/Components/FlarePlanetaryBox.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "../../Flare.h"
-#include "SlateStructs.h"
+#include <Types/SlateStructs.h>
 
 
 class SFlarePlanetaryBox : public SPanel

--- a/Source/HeliumRain/UI/Components/FlareRoundButton.cpp
+++ b/Source/HeliumRain/UI/Components/FlareRoundButton.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareRoundButton.h"
+#include "HeliumRain/UI/Components/FlareRoundButton.h"
 #include "../../Flare.h"
 #include "../../Player/FlareMenuManager.h"
 

--- a/Source/HeliumRain/UI/Components/FlareRoundButton.h
+++ b/Source/HeliumRain/UI/Components/FlareRoundButton.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../../Flare.h"
-#include "FlareButton.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
 
 
 class SFlareRoundButton : public SCompoundWidget

--- a/Source/HeliumRain/UI/Components/FlareSectorButton.cpp
+++ b/Source/HeliumRain/UI/Components/FlareSectorButton.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSectorButton.h"
+#include "HeliumRain/UI/Components/FlareSectorButton.h"
 #include "../../Flare.h"
 
 #include "../../Game/FlareGame.h"

--- a/Source/HeliumRain/UI/Components/FlareSectorButton.h
+++ b/Source/HeliumRain/UI/Components/FlareSectorButton.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "../../Flare.h"
-#include "FlareButton.h"
-#include "Widgets/Text/STextBlock.h"
-#include "Widgets/Layout/SBorder.h"
-#include "Widgets/Input/SButton.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
+#include <Widgets/Text/STextBlock.h>
+#include <Widgets/Layout/SBorder.h>
+#include <Widgets/Input/SButton.h>
 
 
 class UFlareCompany;

--- a/Source/HeliumRain/UI/Components/FlareShipStatus.cpp
+++ b/Source/HeliumRain/UI/Components/FlareShipStatus.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareShipStatus.h"
+#include "HeliumRain/UI/Components/FlareShipStatus.h"
 #include "../../Flare.h"
 
 #include "../../Data/FlareSpacecraftComponentsCatalog.h"

--- a/Source/HeliumRain/UI/Components/FlareSpacecraftInfo.cpp
+++ b/Source/HeliumRain/UI/Components/FlareSpacecraftInfo.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSpacecraftInfo.h"
+#include "HeliumRain/UI/Components/FlareSpacecraftInfo.h"
 #include "../../Flare.h"
 
 #include "../../Data/FlareSpacecraftCatalog.h"
@@ -15,7 +15,7 @@
 #include "../../Player/FlareMenuManager.h"
 #include "../../Player/FlarePlayerController.h"
 
-#include "FlareCargoInfo.h"
+#include "HeliumRain/UI/Components/FlareCargoInfo.h"
 
 #define LOCTEXT_NAMESPACE "FlareSpacecraftInfo"
 

--- a/Source/HeliumRain/UI/Components/FlareSpacecraftOrderOverlay.cpp
+++ b/Source/HeliumRain/UI/Components/FlareSpacecraftOrderOverlay.cpp
@@ -1,8 +1,8 @@
 
-#include "FlareSpacecraftOrderOverlay.h"
+#include "HeliumRain/UI/Components/FlareSpacecraftOrderOverlay.h"
 #include "../../Flare.h"
 
-#include "FlareFactoryInfo.h"
+#include "HeliumRain/UI/Components/FlareFactoryInfo.h"
 #include "../Menus/FlareShipMenu.h"
 
 #include "../../Player/FlareMenuManager.h"
@@ -12,7 +12,7 @@
 #include "../../Game/FlareGameTools.h"
 #include "../../Game/FlareSkirmishManager.h"
 
-#include "SBackgroundBlur.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 #define LOCTEXT_NAMESPACE "FlareSpacecraftOrderOverlay"
 

--- a/Source/HeliumRain/UI/Components/FlareTabView.cpp
+++ b/Source/HeliumRain/UI/Components/FlareTabView.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareTabView.h"
+#include "HeliumRain/UI/Components/FlareTabView.h"
 #include "../../Flare.h"
 #include "../Style/FlareStyleSet.h"
 

--- a/Source/HeliumRain/UI/Components/FlareTabView.h
+++ b/Source/HeliumRain/UI/Components/FlareTabView.h
@@ -3,9 +3,9 @@
 #include "../../Flare.h"
 #include "../Components/FlareButton.h"
 
-#include "Widgets/SCompoundWidget.h"
-#include "Widgets/Layout/SWidgetSwitcher.h"
-#include "Widgets/SBoxPanel.h"
+#include <Widgets/SCompoundWidget.h>
+#include <Widgets/Layout/SWidgetSwitcher.h>
+#include <Widgets/SBoxPanel.h>
 
 
 class SFlareTabView : public SCompoundWidget

--- a/Source/HeliumRain/UI/Components/FlareTechnologyInfo.cpp
+++ b/Source/HeliumRain/UI/Components/FlareTechnologyInfo.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareTechnologyInfo.h"
+#include "HeliumRain/UI/Components/FlareTechnologyInfo.h"
 #include "../../Flare.h"
 #include "../Menus/FlareTechnologyMenu.h"
 #include "../../Player/FlareMenuManager.h"

--- a/Source/HeliumRain/UI/Components/FlareTechnologyInfo.h
+++ b/Source/HeliumRain/UI/Components/FlareTechnologyInfo.h
@@ -2,7 +2,7 @@
 
 #include "../../Flare.h"
 #include "../../Game/FlareGameTypes.h"
-#include "FlareButton.h"
+#include "HeliumRain/UI/Components/FlareButton.h"
 
 
 class SFlareTechnologyInfo : public SCompoundWidget

--- a/Source/HeliumRain/UI/Components/FlareTooltip.cpp
+++ b/Source/HeliumRain/UI/Components/FlareTooltip.cpp
@@ -1,11 +1,11 @@
 
-#include "FlareTooltip.h"
+#include "HeliumRain/UI/Components/FlareTooltip.h"
 #include "../../Flare.h"
 #include "../../Player/FlareHUD.h"
 #include "../../Player/FlareMenuManager.h"
 #include "../../Player/FlarePlayerController.h"
-#include "Runtime/Engine/Classes/Engine/UserInterfaceSettings.h"
-#include "SBackgroundBlur.h"
+#include <Engine/UserInterfaceSettings.h>
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 #define LOCTEXT_NAMESPACE "FlareTooltip"
 

--- a/Source/HeliumRain/UI/Components/FlareTradeRouteInfo.cpp
+++ b/Source/HeliumRain/UI/Components/FlareTradeRouteInfo.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareTradeRouteInfo.h"
+#include "HeliumRain/UI/Components/FlareTradeRouteInfo.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGameTools.h"
 #include "../../Game/FlareCompany.h"

--- a/Source/HeliumRain/UI/FlareUITypes.cpp
+++ b/Source/HeliumRain/UI/FlareUITypes.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareUITypes.h"
+#include "HeliumRain/UI/FlareUITypes.h"
 #include "../Flare.h"
 
 #define LOCTEXT_NAMESPACE "FlareUITypes"

--- a/Source/HeliumRain/UI/FlareUITypes.h
+++ b/Source/HeliumRain/UI/FlareUITypes.h
@@ -2,8 +2,8 @@
 
 #include "../Spacecrafts/FlareSpacecraftTypes.h"
 
-#include "SlateBasics.h"
-#include "SlateGameResources.h"
+#include <SlateBasics.h>
+#include <Slate/SlateGameResources.h>
 #include "../UI/Style/FlareStyleSet.h"
 
 #include "FlareUITypes.generated.h"

--- a/Source/HeliumRain/UI/HUD/FlareContextMenu.cpp
+++ b/Source/HeliumRain/UI/HUD/FlareContextMenu.cpp
@@ -1,12 +1,12 @@
 
-#include "FlareContextMenu.h"
+#include "HeliumRain/UI/HUD/FlareContextMenu.h"
 #include "../../Flare.h"
 #include "../../Player/FlareHUD.h"
 #include "../../Player/FlareMenuManager.h"
 #include "../../Spacecrafts/FlareSpacecraft.h"
 
-#include "Runtime/Engine/Classes/Engine/UserInterfaceSettings.h"
-#include "Runtime/Engine/Classes/Engine/RendererSettings.h"
+#include <Engine/UserInterfaceSettings.h>
+#include <Engine/RendererSettings.h>
 
 #define LOCTEXT_NAMESPACE "FlareContextMenu"
 

--- a/Source/HeliumRain/UI/HUD/FlareHUDMenu.cpp
+++ b/Source/HeliumRain/UI/HUD/FlareHUDMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareHUDMenu.h"
+#include "HeliumRain/UI/HUD/FlareHUDMenu.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../../Game/FlareGameTools.h"

--- a/Source/HeliumRain/UI/HUD/FlareMouseMenu.cpp
+++ b/Source/HeliumRain/UI/HUD/FlareMouseMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareMouseMenu.h"
+#include "HeliumRain/UI/HUD/FlareMouseMenu.h"
 #include "../../Flare.h"
 
 #include "../../Player/FlareMenuManager.h"
@@ -7,9 +7,9 @@
 
 #include "../Components/FlareRoundButton.h"
 
-#include "SBackgroundBlur.h"
-#include "Runtime/Engine/Classes/Engine/UserInterfaceSettings.h"
-#include "Runtime/Engine/Classes/Engine/RendererSettings.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
+#include <Engine/UserInterfaceSettings.h>
+#include <Engine/RendererSettings.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareMouseMenu"

--- a/Source/HeliumRain/UI/HUD/FlareSubsystemStatus.cpp
+++ b/Source/HeliumRain/UI/HUD/FlareSubsystemStatus.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSubsystemStatus.h"
+#include "HeliumRain/UI/HUD/FlareSubsystemStatus.h"
 #include "../../Flare.h"
 #include "../Components/FlareRoundButton.h"
 #include "../../Spacecrafts/FlareWeapon.h"

--- a/Source/HeliumRain/UI/HUD/FlareWeaponStatus.cpp
+++ b/Source/HeliumRain/UI/HUD/FlareWeaponStatus.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareWeaponStatus.h"
+#include "HeliumRain/UI/HUD/FlareWeaponStatus.h"
 #include "../../Flare.h"
 #include "../Components/FlareRoundButton.h"
 #include "../../Spacecrafts/FlareWeapon.h"

--- a/Source/HeliumRain/UI/Menus/FlareCompanyMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareCompanyMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareCompanyMenu.h"
+#include "HeliumRain/UI/Menus/FlareCompanyMenu.h"
 #include "../../Flare.h"
 
 #include "../Components/FlarePartInfo.h"
@@ -17,7 +17,7 @@
 #include "../../Player/FlareMenuPawn.h"
 #include "../../Player/FlarePlayerController.h"
 
-#include "SBackgroundBlur.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareCompanyMenu"

--- a/Source/HeliumRain/UI/Menus/FlareCreditsMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareCreditsMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareCreditsMenu.h"
+#include "HeliumRain/UI/Menus/FlareCreditsMenu.h"
 #include "../../Flare.h"
 #include "../Components/FlareButton.h"
 #include "../../Game/FlareGame.h"

--- a/Source/HeliumRain/UI/Menus/FlareEULAMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareEULAMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareEULAMenu.h"
+#include "HeliumRain/UI/Menus/FlareEULAMenu.h"
 #include "../../Flare.h"
 #include "../Components/FlareButton.h"
 #include "../../Game/FlareGame.h"

--- a/Source/HeliumRain/UI/Menus/FlareFleetMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareFleetMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareFleetMenu.h"
+#include "HeliumRain/UI/Menus/FlareFleetMenu.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../../Game/FlareCompany.h"
@@ -8,7 +8,7 @@
 #include "../../Player/FlarePlayerController.h"
 #include "../Components/FlareRoundButton.h"
 
-#include "SComplexGradient.h"
+#include <Widgets/Colors/SComplexGradient.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareFleetMenu"

--- a/Source/HeliumRain/UI/Menus/FlareGameOverMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareGameOverMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareGameOverMenu.h"
+#include "HeliumRain/UI/Menus/FlareGameOverMenu.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../../Game/FlareSaveGame.h"
@@ -8,10 +8,10 @@
 #include "../../Player/FlarePlayerController.h"
 
 #include "../Components/FlareButton.h"
-#include "SBackgroundBlur.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
 
-#include "Runtime/Engine/Classes/Engine/UserInterfaceSettings.h"
-#include "Runtime/Engine/Classes/Engine/RendererSettings.h"
+#include <Engine/UserInterfaceSettings.h>
+#include <Engine/RendererSettings.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareGameOverMenu"

--- a/Source/HeliumRain/UI/Menus/FlareLeaderboardMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareLeaderboardMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareLeaderboardMenu.h"
+#include "HeliumRain/UI/Menus/FlareLeaderboardMenu.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../../Player/FlareMenuManager.h"

--- a/Source/HeliumRain/UI/Menus/FlareMainMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareMainMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareMainMenu.h"
+#include "HeliumRain/UI/Menus/FlareMainMenu.h"
 #include "../../Flare.h"
 
 #include "../../Game/FlareGame.h"
@@ -10,9 +10,9 @@
 #include "../../Player/FlareMenuManager.h"
 #include "../../Player/FlarePlayerController.h"
 
-#include "Runtime/Projects/Public/Interfaces/IPluginManager.h"
+#include <Interfaces/IPluginManager.h>
 
-#include "SBackgroundBlur.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareMainMenu"

--- a/Source/HeliumRain/UI/Menus/FlareMainMenu.h
+++ b/Source/HeliumRain/UI/Menus/FlareMainMenu.h
@@ -2,7 +2,7 @@
 
 #include "../../Flare.h"
 #include "../Components/FlareButton.h"
-#include "SlateMaterialBrush.h"
+#include <SlateMaterialBrush.h>
 
 
 class AFlareMenuManager;

--- a/Source/HeliumRain/UI/Menus/FlareNewGameMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareNewGameMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareNewGameMenu.h"
+#include "HeliumRain/UI/Menus/FlareNewGameMenu.h"
 #include "../../Flare.h"
 
 #include "../../Data/FlareCompanyCatalog.h"
@@ -14,8 +14,8 @@
 #include "../../Player/FlarePlayerController.h"
 
 #include "../FlareUITypes.h"
-#include "STextComboBox.h"
-#include "GameFramework/PlayerState.h"
+#include <Widgets/Input/STextComboBox.h>
+#include <GameFramework/PlayerState.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareNewGameMenu"

--- a/Source/HeliumRain/UI/Menus/FlareOrbitalMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareOrbitalMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareOrbitalMenu.h"
+#include "HeliumRain/UI/Menus/FlareOrbitalMenu.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../../Game/FlareGameTools.h"

--- a/Source/HeliumRain/UI/Menus/FlareQuestMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareQuestMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareQuestMenu.h"
+#include "HeliumRain/UI/Menus/FlareQuestMenu.h"
 #include "../../Flare.h"
 
 #include "../../Game/FlareGame.h"

--- a/Source/HeliumRain/UI/Menus/FlareQuestMenu.h
+++ b/Source/HeliumRain/UI/Menus/FlareQuestMenu.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "../../Flare.h"
-#include "Widgets/SCompoundWidget.h"
-#include "Widgets/Layout/SBorder.h"
-#include "Widgets/SBoxPanel.h"
-#include "Widgets/Text/STextBlock.h"
+#include <Widgets/SCompoundWidget.h>
+#include <Widgets/Layout/SBorder.h>
+#include <Widgets/SBoxPanel.h>
+#include <Widgets/Text/STextBlock.h>
 
 
 class UFlareQuest;

--- a/Source/HeliumRain/UI/Menus/FlareResourcePricesMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareResourcePricesMenu.cpp
@@ -1,7 +1,7 @@
 
-#include "FlareResourcePricesMenu.h"
+#include "HeliumRain/UI/Menus/FlareResourcePricesMenu.h"
 #include "../../Flare.h"
-#include "FlareWorldEconomyMenu.h"
+#include "HeliumRain/UI/Menus/FlareWorldEconomyMenu.h"
 #include "../../Game/FlareGame.h"
 #include "../../Game/FlareSectorHelper.h"
 #include "../../Economy/FlareResource.h"

--- a/Source/HeliumRain/UI/Menus/FlareSectorMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareSectorMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSectorMenu.h"
+#include "HeliumRain/UI/Menus/FlareSectorMenu.h"
 #include "../../Flare.h"
 
 #include "../../Game/FlareGame.h"

--- a/Source/HeliumRain/UI/Menus/FlareSettingsMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareSettingsMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSettingsMenu.h"
+#include "HeliumRain/UI/Menus/FlareSettingsMenu.h"
 
 #include "../../Flare.h"
 #include "../../Game/FlareGameUserSettings.h"
@@ -13,10 +13,10 @@
 
 #include "../Components/FlareTabView.h"
 
-#include "STextComboBox.h"
-#include "Internationalization/Culture.h"
-#include "GameFramework/InputSettings.h"
-#include "Engine.h"
+#include <Widgets/Input/STextComboBox.h>
+#include <Internationalization/Culture.h>
+#include <GameFramework/InputSettings.h>
+#include <Engine.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareSettingsMenu"

--- a/Source/HeliumRain/UI/Menus/FlareSettingsMenu.h
+++ b/Source/HeliumRain/UI/Menus/FlareSettingsMenu.h
@@ -3,9 +3,9 @@
 #include "../../Flare.h"
 #include "../Components/FlareButton.h"
 #include "../Components/FlareColorPanel.h"
-#include "SlateMaterialBrush.h"
+#include <SlateMaterialBrush.h>
 #include "../Components/FlareKeyBind.h"
-#include "GameFramework/PlayerInput.h"
+#include <GameFramework/PlayerInput.h>
 
 class AFlareGame;
 class AFlareMenuManager;

--- a/Source/HeliumRain/UI/Menus/FlareShipMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareShipMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareShipMenu.h"
+#include "HeliumRain/UI/Menus/FlareShipMenu.h"
 
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"

--- a/Source/HeliumRain/UI/Menus/FlareSkirmishScoreMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareSkirmishScoreMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSkirmishScoreMenu.h"
+#include "HeliumRain/UI/Menus/FlareSkirmishScoreMenu.h"
 #include "../../Flare.h"
 
 #include "../Components/FlareButton.h"

--- a/Source/HeliumRain/UI/Menus/FlareSkirmishScoreMenu.h
+++ b/Source/HeliumRain/UI/Menus/FlareSkirmishScoreMenu.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "../../Flare.h"
-#include "Widgets/SCompoundWidget.h"
-#include "Widgets/SBoxPanel.h"
-#include "Widgets/Text/STextBlock.h"
+#include <Widgets/SCompoundWidget.h>
+#include <Widgets/SBoxPanel.h>
+#include <Widgets/Text/STextBlock.h>
 
 
 class AFlareMenuManager;

--- a/Source/HeliumRain/UI/Menus/FlareSkirmishSetupMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareSkirmishSetupMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareSkirmishSetupMenu.h"
+#include "HeliumRain/UI/Menus/FlareSkirmishSetupMenu.h"
 #include "../../Flare.h"
 
 #include "../../Data/FlareCompanyCatalog.h"

--- a/Source/HeliumRain/UI/Menus/FlareSkirmishSetupMenu.h
+++ b/Source/HeliumRain/UI/Menus/FlareSkirmishSetupMenu.h
@@ -6,7 +6,7 @@
 #include "../Components/FlareDropList.h"
 #include "../Components/FlareListItem.h"
 
-#include "SBackgroundBlur.h"
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 
 struct FFlareCompanyDescription;

--- a/Source/HeliumRain/UI/Menus/FlareStoryMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareStoryMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareStoryMenu.h"
+#include "HeliumRain/UI/Menus/FlareStoryMenu.h"
 
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
@@ -9,9 +9,9 @@
 #include "../../Player/FlareMenuManager.h"
 #include "../../Player/FlarePlayerController.h"
 
-#include "Runtime/Engine/Classes/Engine/UserInterfaceSettings.h"
-#include "Runtime/Engine/Classes/Engine/RendererSettings.h"
-#include "SBackgroundBlur.h"
+#include <Engine/UserInterfaceSettings.h>
+#include <Engine/RendererSettings.h>
+#include <Widgets/Layout/SBackgroundBlur.h>
 
 
 #define LOCTEXT_NAMESPACE "FlareStoryMenu"

--- a/Source/HeliumRain/UI/Menus/FlareTechnologyMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareTechnologyMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareTechnologyMenu.h"
+#include "HeliumRain/UI/Menus/FlareTechnologyMenu.h"
 #include "../../Flare.h"
 
 #include "../Components/FlareTechnologyInfo.h"

--- a/Source/HeliumRain/UI/Menus/FlareTradeMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareTradeMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareTradeMenu.h"
+#include "HeliumRain/UI/Menus/FlareTradeMenu.h"
 
 #include "../../Flare.h"
 

--- a/Source/HeliumRain/UI/Menus/FlareTradeRouteMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareTradeRouteMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareTradeRouteMenu.h"
+#include "HeliumRain/UI/Menus/FlareTradeRouteMenu.h"
 #include "../../Flare.h"
 
 #include "../../Data/FlareResourceCatalog.h"

--- a/Source/HeliumRain/UI/Menus/FlareWorldEconomyMenu.cpp
+++ b/Source/HeliumRain/UI/Menus/FlareWorldEconomyMenu.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareWorldEconomyMenu.h"
+#include "HeliumRain/UI/Menus/FlareWorldEconomyMenu.h"
 #include "../../Flare.h"
 #include "../../Game/FlareGame.h"
 #include "../../Game/FlareGameTools.h"

--- a/Source/HeliumRain/UI/Style/FlareScalingRule.cpp
+++ b/Source/HeliumRain/UI/Style/FlareScalingRule.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareScalingRule.h"
+#include "HeliumRain/UI/Style/FlareScalingRule.h"
 
 float UFlareScalingRule::GetDPIScaleBasedOnSize(FIntPoint Size) const
 {

--- a/Source/HeliumRain/UI/Style/FlareScalingRule.h
+++ b/Source/HeliumRain/UI/Style/FlareScalingRule.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Engine/DPICustomScalingRule.h"
+#include <Engine/DPICustomScalingRule.h>
 #include "FlareScalingRule.generated.h"
 
 

--- a/Source/HeliumRain/UI/Style/FlareStyleSet.cpp
+++ b/Source/HeliumRain/UI/Style/FlareStyleSet.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareStyleSet.h"
+#include "HeliumRain/UI/Style/FlareStyleSet.h"
 #include "../../Flare.h"
 
 

--- a/Source/HeliumRain/UI/Style/FlareStyleSet.h
+++ b/Source/HeliumRain/UI/Style/FlareStyleSet.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "SlateBasics.h"
-#include "SlateGameResources.h"
-#include "FlareWidgetStyleCatalog.h"
+#include <SlateBasics.h>
+#include <Slate/SlateGameResources.h>
+#include "HeliumRain/UI/Style/FlareWidgetStyleCatalog.h"
 
 
 class FFlareStyleSet

--- a/Source/HeliumRain/UI/Style/FlareWidgetStyleCatalog.cpp
+++ b/Source/HeliumRain/UI/Style/FlareWidgetStyleCatalog.cpp
@@ -1,5 +1,5 @@
 
-#include "FlareWidgetStyleCatalog.h"
+#include "HeliumRain/UI/Style/FlareWidgetStyleCatalog.h"
 #include "../../Flare.h"
 
 const FName FFlareStyleCatalog::TypeName(TEXT("FFlareStyleCatalog"));

--- a/Source/HeliumRainEditor.Target.cs
+++ b/Source/HeliumRainEditor.Target.cs
@@ -8,6 +8,7 @@ public class HeliumRainEditorTarget : TargetRules
 	public HeliumRainEditorTarget(TargetInfo Target) : base(Target)
     {
 		Type = TargetType.Editor;
+		DefaultBuildSettings = BuildSettingsVersion.V2;
         ExtraModuleNames.Add("HeliumRain");
         ExtraModuleNames.Add("HeliumRainLoadingScreen");
     }

--- a/Source/HeliumRainLoadingScreen/FlareLoadingScreen.cpp
+++ b/Source/HeliumRainLoadingScreen/FlareLoadingScreen.cpp
@@ -1,10 +1,10 @@
 
-#include "FlareLoadingScreen.h"
+#include "HeliumRainLoadingScreen/FlareLoadingScreen.h"
 
-#include "SlateBasics.h"
-#include "SlateExtras.h"
-#include "MoviePlayer.h"
-#include "SThrobber.h"
+#include <SlateBasics.h>
+#include <SlateExtras.h>
+#include <MoviePlayer.h>
+#include <Widgets/Images/SThrobber.h>
 
 #define LOCTEXT_NAMESPACE "FlareLoadingScreen"
 

--- a/Source/HeliumRainLoadingScreen/FlareLoadingScreen.h
+++ b/Source/HeliumRainLoadingScreen/FlareLoadingScreen.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ModuleInterface.h"
+#include <Modules/ModuleInterface.h>
 
 
 class IFlareLoadingScreenModule : public IModuleInterface


### PR DESCRIPTION
This PR adds DefaultBuildSettings = BuildSettingsVersion.V2; to the editor project Target.cs file and related header fixes generated by the tool mentioned below.

------------

When developing using JetBrains Rider for Unreal Engine the compile can fail with:

> command line is too long to fit in debug record

The problem (and tool to fix) is discussed furthur in this thread:

[A script to fixup includes for Unreal Engine 4.24](http://www.aclockworkberry.com/a-script-to-fixup-includes-for-unreal-engine-4-24/)

I did confirm that running the tool on HeliumStorm resolves this issue and tested a successful compile.
